### PR TITLE
Decode JWT private claims

### DIFF
--- a/jws/jws.go
+++ b/jws/jws.go
@@ -119,7 +119,19 @@ func Decode(payload string) (c *ClaimSet, err error) {
 	}
 	c = &ClaimSet{}
 	err = json.NewDecoder(bytes.NewBuffer(decoded)).Decode(c)
-	return c, err
+	if err != nil {
+		return nil, err
+	}
+	// decode private claims
+	err = json.NewDecoder(bytes.NewBuffer(decoded)).Decode(&c.PrivateClaims)
+	if err != nil {
+		return nil, err
+	}
+	// unset registered (and used) claims
+	for _, claim := range []string{"iss", "aud", "exp", "iat"} {
+		delete(c.PrivateClaims, claim)
+	}
+	return c, nil
 }
 
 // Encode encodes a signed JWS with provided header and claim set.

--- a/jws/jws_test.go
+++ b/jws/jws_test.go
@@ -1,31 +1,42 @@
+// Copyright 2014 The oauth2 Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
 package jws_test
 
 import (
 	"testing"
 
-	. "github.com/golang/oauth2/jws"
+	"github.com/golang/oauth2/jws"
 )
 
 func TestDecode(t *testing.T) {
 	// example JWT taken from https://developers.google.com/wallet/digital/docs/jsreference
-	jws := "eyJhbGciOiAiSFMyNTYiLCAidHlwIjogIkpXVCJ9." +
+	example := "eyJhbGciOiAiSFMyNTYiLCAidHlwIjogIkpXVCJ9." +
 		"eyJleHAiOiAxMzA5OTkxNzY0LCAiYXVkIjogImdvb2cucGF5bWVudHMuaW5hcHAuYnV5SXRlbSIsICJpc3MiOiAiMTA4NzM2NjAzNTQ2MjAwOTQ3MTYiLCAic2VsbGVyRGF0YSI6ICJfc2VsbGVyX2RhdGFfIiwgIml0ZW1EZXNjcmlwdGlvbiI6ICJUaGUgc2FmZXRpZXN0IHdheSB0byBkaXNwbGF5IHlvdXIgZmxhaXIiLCAiaXRlbVByaWNlIjogIjMuOTkiLCAiaXNvQ3VycmVuY3lDb2RlIjogIlVTRCIsICJpYXQiOiAxMzA5OTkxMTY0LCAiaXRlbU5hbWUiOiAiU2FmZXR5bW91c2UgUGF0Y2gifQ." +
 		"E1VH0T9DvQn4GdCjyVavnlurpx0iklQXlqeI1_tAMa8"
 
-	claimSet, err := Decode(jws)
+	claimSet, err := jws.Decode(example)
 	if err != nil {
-		t.Fatalf("failed to decode JWT: %v", err)
+		t.Errorf("failed to decode JWT: %v", err)
 	}
 	if claimSet.Iss != "10873660354620094716" {
-		t.Fatalf("received iss = %v; want 10873660354620094716", claimSet.Iss)
+		t.Errorf("received iss = %v; want 10873660354620094716", claimSet.Iss)
 	}
 	if claimSet.Aud != "goog.payments.inapp.buyItem" {
-		t.Fatalf("received aud = %v; want goog.payments.inapp.buyItem", claimSet.Aud)
+		t.Errorf("received aud = %v; want goog.payments.inapp.buyItem", claimSet.Aud)
 	}
 	if claimSet.Exp != 1309991764 {
-		t.Fatalf("received exp = %v; want 1309991764", claimSet.Exp)
+		t.Errorf("received exp = %v; want 1309991764", claimSet.Exp)
 	}
 	if claimSet.Iat != 1309991164 {
-		t.Fatalf("received iat = %v; want 1309991164", claimSet.Iat)
+		t.Errorf("received iat = %v; want 1309991164", claimSet.Iat)
+	}
+
+	if claimSet.PrivateClaims["sellerData"] != "_seller_data_" {
+		t.Errorf("received sellerData = %v; want _seller_data_", claimSet.PrivateClaims["sellerData"])
+	}
+	if claimSet.PrivateClaims["aud"] != nil {
+		t.Errorf("found registered claim in private claims")
 	}
 }


### PR DESCRIPTION
- Add a basic test around `jws.Decode`
- Decode private claims when decoding a claim set

Note that this puts all claims that are not set on `ClaimSet` into `PrivateClaims`. This is not strictly correct as there are a number of registered claims that are not used by this library. However, it seemed like the least confusing thing to do.
