### PR TITLE
JWT validation

### DIFF
--- a/jws/jws.go
+++ b/jws/jws.go
@@ -49,17 +49,20 @@ type ClaimSet struct {
 }
 
 func (c *ClaimSet) encode() (string, error) {
-	if c.exp.IsZero() || c.iat.IsZero() {
-		// Reverting time back for machines whose time is not perfectly in sync.
-		// If client machine's time is in the future according
-		// to Google servers, an access token will not be issued.
-		now := time.Now().Add(-10 * time.Second)
+	// Reverting time back for machines whose time is not perfectly in sync.
+	// If client machine's time is in the future according
+	// to Google servers, an access token will not be issued.
+	now := time.Now().Add(-10 * time.Second)
+	if c.iat.IsZero() {
 		c.iat = now
-		c.exp = now.Add(time.Hour)
 	}
-
-	c.Exp = c.exp.Unix()
 	c.Iat = c.iat.Unix()
+
+	// Only set the expiry if it has not been manually set
+	if c.Exp == 0 {
+		c.exp = now.Add(time.Hour)
+		c.Exp = c.exp.Unix()
+	}
 
 	b, err := json.Marshal(c)
 	if err != nil {
@@ -95,6 +98,8 @@ type Header struct {
 
 	// Represents the token type.
 	Typ string `json:"typ"`
+
+	Kid string `json:"kid"`
 }
 
 func (h *Header) encode() (string, error) {
@@ -132,6 +137,72 @@ func Decode(payload string) (c *ClaimSet, err error) {
 		delete(c.PrivateClaims, claim)
 	}
 	return c, nil
+}
+
+func decodeHeader(payload string) (h *Header, err error) {
+	s := strings.Split(payload, ".")
+	if len(s) < 1 {
+		return nil, errors.New("invalid token received")
+	}
+	decoded, err := base64Decode(s[0])
+	if err != nil {
+		return nil, err
+	}
+	h = &Header{}
+	err = json.NewDecoder(bytes.NewBuffer(decoded)).Decode(h)
+	return
+}
+
+func Validate(payload string, public_key interface{}, audience string) error {
+	header, err := decodeHeader(payload)
+	if err != nil {
+		return err
+	}
+
+	// check signature
+	parts := strings.Split(payload, ".")
+	signed := strings.Join(parts[0:2], ".")
+	signature, err := base64Decode(parts[2])
+	if err != nil {
+		return err
+	}
+
+	var algo x509.SignatureAlgorithm
+
+	switch public_key.(type) {
+	case *rsa.PublicKey:
+		switch header.Algorithm {
+		case "RS256":
+			algo = x509.SHA256WithRSA
+		case "RS512":
+			algo = x509.SHA512WithRSA
+		default:
+			return errors.New("JWS algorithm does not match provided key")
+		}
+	default:
+		return errors.New("Unsupported algorithm")
+	}
+
+	cert := x509.Certificate{PublicKey: public_key}
+	err = cert.CheckSignature(algo, []byte(signed), signature)
+	if err != nil {
+		return err
+	}
+
+	claimSet, err := Decode(payload)
+	if err != nil {
+		return err
+	}
+
+	// check expiry
+	if time.Unix(claimSet.Exp, 0).Before(time.Now()) {
+		return errors.New("JWT has expired")
+	}
+
+	if claimSet.Aud != audience {
+		return errors.New("wrong recipient")
+	}
+	return nil
 }
 
 // Encode encodes a signed JWS with provided header and claim set.

--- a/jws/jws_test.go
+++ b/jws/jws_test.go
@@ -5,18 +5,26 @@
 package jws_test
 
 import (
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/pem"
 	"testing"
+	"time"
 
 	"github.com/golang/oauth2/jws"
 )
 
-func TestDecode(t *testing.T) {
-	// example JWT taken from https://developers.google.com/wallet/digital/docs/jsreference
-	example := "eyJhbGciOiAiSFMyNTYiLCAidHlwIjogIkpXVCJ9." +
-		"eyJleHAiOiAxMzA5OTkxNzY0LCAiYXVkIjogImdvb2cucGF5bWVudHMuaW5hcHAuYnV5SXRlbSIsICJpc3MiOiAiMTA4NzM2NjAzNTQ2MjAwOTQ3MTYiLCAic2VsbGVyRGF0YSI6ICJfc2VsbGVyX2RhdGFfIiwgIml0ZW1EZXNjcmlwdGlvbiI6ICJUaGUgc2FmZXRpZXN0IHdheSB0byBkaXNwbGF5IHlvdXIgZmxhaXIiLCAiaXRlbVByaWNlIjogIjMuOTkiLCAiaXNvQ3VycmVuY3lDb2RlIjogIlVTRCIsICJpYXQiOiAxMzA5OTkxMTY0LCAiaXRlbU5hbWUiOiAiU2FmZXR5bW91c2UgUGF0Y2gifQ." +
-		"E1VH0T9DvQn4GdCjyVavnlurpx0iklQXlqeI1_tAMa8"
+// 1024 bit PEM encoded RSA
+const PRIVATE_KEY string = "-----BEGIN RSA PRIVATE KEY-----\nMIICXAIBAAKBgQDPcK7IhOV9mk7aXz+jcxdUoPiKUI17gmQ7UTCT9L50nTyP2Qbr\nunwqPWYU5/r+n2EQdb7kBo8Sau8ct6TzbIF2E4QNkoMvedknxA1kRL89Os+OXpKy\nTIyIi0ua1krWBaX3oLfHSlkvINudmQZ9v1C3oXRKba6L8htIm427i2ePBwIDAQAB\nAoGAGtQcBtsJQ0FdyWhgNqd/8PYQrvLUGZE3nWRWwAv7ReHAH2qWNo6b2GqwdSu7\njorWZuaTlbIzdtJVsoUd1E3IQF13JTV50ZRHQVSMJuwDx37k47euzyvMFwh9zYjg\nMh7aezjTLhMNBNRJ03PghaYRbFMglk+0oxck5ALxkHwtmKECQQD0igtMvx/MJUqg\npWzfAoHXYTHk4FKR55CAKoKwyIrfvMIM+gqWlI37OaczDUp+JI8HwgRkt1AzHPRj\nk5AtjxwNAkEA2SmHJYnbyXbOKeKbNooBf89qOwo9GSQ4Dl2uPAxpYTYaiUdf+OZW\n7du34yKXsRJ5aCLTnhRDueuCAuSuouMOYwJBANPYbzeab2qEd+U5ylpcKq2ypu23\no/CAYj+WFEggQ6bWOGnTh66xnVqhtIZWok0rULmQzAuQfyr4j4NgR8wgKVUCQE9D\noimofQm3DJ8rMD4i91MgcQTlwtFXcAKGXR9b5GbwKZVr8PLXmGkvZppIORgPxzKk\na5tqiCHnfUfzEm8v80MCQGKE3zodVtQfVXYxpbfer4za6lNzEWqY8FXZ4yR+lted\nmmGMi8/RM2yDWO8/3uAcwrJ4CyEIpJt/dhZa7jtyxA0=\n-----END RSA PRIVATE KEY-----\n"
+const PUBLIC_KEY string = "-----BEGIN RSA PUBLIC KEY-----\nMIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQDPcK7IhOV9mk7aXz+jcxdUoPiK\nUI17gmQ7UTCT9L50nTyP2QbrunwqPWYU5/r+n2EQdb7kBo8Sau8ct6TzbIF2E4QN\nkoMvedknxA1kRL89Os+OXpKyTIyIi0ua1krWBaX3oLfHSlkvINudmQZ9v1C3oXRK\nba6L8htIm427i2ePBwIDAQAB\n-----END RSA PUBLIC KEY-----\n"
 
-	claimSet, err := jws.Decode(example)
+// example JWT taken from https://developers.google.com/wallet/digital/docs/jsreference
+const EXAMPLE_JWT string = "eyJhbGciOiAiSFMyNTYiLCAidHlwIjogIkpXVCJ9." +
+	"eyJleHAiOiAxMzA5OTkxNzY0LCAiYXVkIjogImdvb2cucGF5bWVudHMuaW5hcHAuYnV5SXRlbSIsICJpc3MiOiAiMTA4NzM2NjAzNTQ2MjAwOTQ3MTYiLCAic2VsbGVyRGF0YSI6ICJfc2VsbGVyX2RhdGFfIiwgIml0ZW1EZXNjcmlwdGlvbiI6ICJUaGUgc2FmZXRpZXN0IHdheSB0byBkaXNwbGF5IHlvdXIgZmxhaXIiLCAiaXRlbVByaWNlIjogIjMuOTkiLCAiaXNvQ3VycmVuY3lDb2RlIjogIlVTRCIsICJpYXQiOiAxMzA5OTkxMTY0LCAiaXRlbU5hbWUiOiAiU2FmZXR5bW91c2UgUGF0Y2gifQ." +
+	"E1VH0T9DvQn4GdCjyVavnlurpx0iklQXlqeI1_tAMa8"
+
+func TestDecode(t *testing.T) {
+	claimSet, err := jws.Decode(EXAMPLE_JWT)
 	if err != nil {
 		t.Errorf("failed to decode JWT: %v", err)
 	}
@@ -38,5 +46,57 @@ func TestDecode(t *testing.T) {
 	}
 	if claimSet.PrivateClaims["aud"] != nil {
 		t.Errorf("found registered claim in private claims")
+	}
+}
+
+func decodePublicKey(key string) *rsa.PublicKey {
+	block, _ := pem.Decode([]byte(key))
+	pub, err := x509.ParsePKIXPublicKey(block.Bytes)
+	if err != nil {
+		panic(err)
+	}
+	return pub.(*rsa.PublicKey)
+}
+
+func TestValidate(t *testing.T) {
+	key := decodePublicKey(PUBLIC_KEY)
+	var tests = []struct {
+		claimSet jws.ClaimSet
+		audience string
+		valid    bool
+		message  string
+	}{
+		{
+			claimSet: jws.ClaimSet{Iss: "just.me", PrivateClaims: map[string]interface{}{"email": "joe@example.com"}},
+			audience: "",
+			valid:    true,
+			message:  "",
+		},
+		{
+			claimSet: jws.ClaimSet{Iss: "just.me", Exp: time.Now().Unix()},
+			audience: "",
+			valid:    false,
+			message:  "token expired",
+		},
+		{
+			claimSet: jws.ClaimSet{Iss: "just.me", Aud: "joe.blogs"},
+			audience: "jack.blogs",
+			valid:   false,
+			message: "audience mismatch",
+		},
+		// TODO: add support for "nbf" (Not Before) claim
+	}
+	for _, test := range tests {
+		header := jws.Header{Algorithm: "RS256"}
+		jwt, err := jws.Encode(&header, &test.claimSet, []byte(PRIVATE_KEY))
+		if err != nil {
+			t.Fatal(err)
+		}
+		err = jws.Validate(jwt, key, test.audience)
+		if test.valid && err != nil {
+			t.Error(err)
+		} else if !test.valid && err == nil {
+			t.Errorf("did not receive expected error: %v", test.message)
+		}
 	}
 }


### PR DESCRIPTION
Depends on https://github.com/golang/oauth2/pull/17 

Inside the Validate function:
- Only supports RS256 and RS512 algorithms
- Verifies signature, expiry and audience
- Does not verify 'not before' or usage before issue time

Outside the Validate function:
- The setting of the iat and exp fields has been changed so that Exp can
  be overriden. The behaviour is the same when nothing is set, but if Exp
  has been set it will be used.
- Add the Kid field to the Header struct. This is so that JSON Web Keys
  can be looked up in a JSON Web Key set.
