### PR TITLE
Add Dropbox to the providers not supporting Auth headers.

### DIFF
--- a/oauth2.go
+++ b/oauth2.go
@@ -289,7 +289,8 @@ func providerAuthHeaderWorks(tokenURL string) bool {
 	if strings.HasPrefix(tokenURL, "https://accounts.google.com/") ||
 		strings.HasPrefix(tokenURL, "https://github.com/") ||
 		strings.HasPrefix(tokenURL, "https://api.instagram.com/") ||
-		strings.HasPrefix(tokenURL, "https://www.douban.com/") {
+		strings.HasPrefix(tokenURL, "https://www.douban.com/") ||
+		strings.HasPrefix(tokenURL, "https://api.dropbox.com/") {
 		// Some sites fail to implement the OAuth2 spec fully.
 		return false
 	}


### PR DESCRIPTION
Dropbox does not support mixing URL param and Auth header for authentication but the retrieveToken method forces the client_id to be sent in the URL param.
