### PR TITLE
Add Linkedin to the providers not supporting Auth headers.

### DIFF
--- a/oauth2.go
+++ b/oauth2.go
@@ -286,7 +286,8 @@ func providerAuthHeaderWorks(tokenURL string) bool {
 		strings.HasPrefix(tokenURL, "https://github.com/") ||
 		strings.HasPrefix(tokenURL, "https://api.instagram.com/") ||
 		strings.HasPrefix(tokenURL, "https://www.douban.com/") ||
-		strings.HasPrefix(tokenURL, "https://api.dropbox.com/") {
+		strings.HasPrefix(tokenURL, "https://api.dropbox.com/") ||
+		strings.HasPrefix(tokenURL, "https://www.linkedin.com/") {
 		// Some sites fail to implement the OAuth2 spec fully.
 		return false
 	}


### PR DESCRIPTION
Access to Linkedin API returns this:
{"error_description":"missing required parameters, includes an invalid parameter value, parameter more than once. : client_secret","error":"invalid_request"}

see also https://code.google.com/p/goauth2/issues/detail?id=43
