### PR TITLE
Update metadata server URL to be a FQDN.

### DIFF
--- a/google/google.go
+++ b/google/google.go
@@ -103,7 +103,7 @@ func (c *ComputeEngineConfig) FetchToken(existing *oauth2.Token) (token *oauth2.
 	if c.account != "" {
 		account = c.account
 	}
-	u := "http://metadata/computeMetadata/v1/instance/service-accounts/" + account + "/token"
+	u := "http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/" + account + "/token"
 	req, err := http.NewRequest("GET", u, nil)
 	if err != nil {
 		return


### PR DESCRIPTION
Without a fully qualified domain name, containers (like Docker) can't
connect to the metadata server. Update the address for the metadata
server to be a FQDN so containers can use the library. See golang/oauth2#44.

I've tested this inside of Docker on CoreOS running on GCE, and can verify that
I have access to service accounts there.
