### PR TITLE
Handle expiry correctly in json response

### DIFF
--- a/oauth2.go
+++ b/oauth2.go
@@ -323,14 +323,14 @@ func retrieveToken(o *Options, v url.Values) (*Token, error) {
 		token.TokenType, _ = b["token_type"].(string)
 		token.RefreshToken, _ = b["refresh_token"].(string)
 		token.raw = b
-		e, ok := b["expires_in"].(int)
+		e, ok := b["expires_in"].(float64)
 		if !ok {
 			// TODO(jbd): Facebook's OAuth2 implementation is broken and
 			// returns expires_in field in expires. Remove the fallback to expires,
 			// when Facebook fixes their implementation.
-			e, _ = b["expires"].(int)
+			e, _ = b["expires"].(float64)
 		}
-		expires = e
+		expires = int(e)
 	}
 	// Don't overwrite `RefreshToken` with an empty value
 	// if this was a token refreshing request.

--- a/oauth2_test.go
+++ b/oauth2_test.go
@@ -115,7 +115,7 @@ func TestExchangeRequest_JSONResponse(t *testing.T) {
 			t.Errorf("Unexpected exchange payload, %v is found.", string(body))
 		}
 		w.Header().Set("Content-Type", "application/json")
-		w.Write([]byte(`{"access_token": "90d64460d14870c08c81352a05dedd3465940a7c", "scope": "user", "token_type": "bearer"}`))
+		w.Write([]byte(`{"access_token": "90d64460d14870c08c81352a05dedd3465940a7c", "scope": "user", "token_type": "bearer", "expires_in": 86400}`))
 	}))
 	defer ts.Close()
 	f := newTestFlow(ts.URL)
@@ -124,6 +124,9 @@ func TestExchangeRequest_JSONResponse(t *testing.T) {
 		t.Error(err)
 	}
 	tok := tr.Token()
+	if tok.Expiry.IsZero() {
+		t.Errorf("Token expiry should not be zero.")
+	}
 	if tok.Expired() {
 		t.Errorf("Token shouldn't be expired.")
 	}


### PR DESCRIPTION
Go treats json numbers as `float64` not `int`, so currently expiry information is ignored for json responses since it's treated as an int.
