### PR TITLE
Do not depend on appenginevm runtime by default.

### DIFF
--- a/google/appenginevm.go
+++ b/google/appenginevm.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-// +build appenginevm !appengine
+// +build appenginevm,!appengine
 
 package google
 

--- a/google/appenginevm_test.go
+++ b/google/appenginevm_test.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-// +build appenginevm !appengine
+// +build appenginevm,!appengine
 
 package google
 

--- a/google/example_test.go
+++ b/google/example_test.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-// +build appenginevm !appengine
+// +build appenginevm,!appengine
 
 package google_test
 


### PR DESCRIPTION
Use appenginevm library only when fetching or building with 'appenginevm' tag.
This change makes oauth2 library easier to vendor, since it has no dependencies
now besides the standard library.