### PR TITLE
Allow expires to be consumed from JSON responses

### DIFF
--- a/oauth2.go
+++ b/oauth2.go
@@ -343,14 +343,14 @@ func retrieveToken(o *Options, v url.Values) (*Token, error) {
 		token.TokenType, _ = b["token_type"].(string)
 		token.RefreshToken, _ = b["refresh_token"].(string)
 		token.raw = b
-		e, ok := b["expires_in"].(int)
+		e, ok := b["expires_in"].(float64)
 		if !ok {
 			// TODO(jbd): Facebook's OAuth2 implementation is broken and
 			// returns expires_in field in expires. Remove the fallback to expires,
 			// when Facebook fixes their implementation.
-			e, _ = b["expires"].(int)
+			e, _ = b["expires"].(float64)
 		}
-		expires = e
+		expires = int(e)
 	}
 	// Don't overwrite `RefreshToken` with an empty value
 	// if this was a token refreshing request.


### PR DESCRIPTION
json.Unmarshal makes all numeric types become a Float64, which means the check for expires_in will always fail.

Extract the field as a float64 and cast to int
