### PR TITLE
Avoid racing to refresh the token and add refresh hysteresis.

### DIFF
--- a/transport_test.go
+++ b/transport_test.go
@@ -60,7 +60,16 @@ func TestExpiredWithExpiry(t *testing.T) {
 		Expiry: time.Now().Add(-5 * time.Hour),
 	}
 	if !token.Expired() {
-		t.Errorf("Token should be expired if no access token is provided")
+		t.Errorf("Token should be expired based on the past date")
+	}
+}
+
+func TestExpiredWithExpiryHyst(t *testing.T) {
+	token := &Token{
+		Expiry: time.Now().Add(5 * time.Second),
+	}
+	if !token.ExpiringSoon() {
+		t.Errorf("Token should be expiring soon")
 	}
 }
 


### PR DESCRIPTION
Currently, if the oauth2 Transport is used concurrently, and a token
refresh occurs, the token refresh procedure can be invoked multiple
times.

The token is also refreshed exactly at expiration - clock skew on the
client may attempt to use an already expired token which a strict
server implementation would reject. The hysteresis is currently static.
