### PR TITLE
Expect unmarshalling of 'expires_in' to be float64 interface value

### DIFF
--- a/jwt.go
+++ b/jwt.go
@@ -136,7 +136,7 @@ func (js jwtSource) Token() (*Token, error) {
 	token.AccessToken, _ = b["access_token"].(string)
 	token.TokenType, _ = b["token_type"].(string)
 	token.raw = b
-	if e, ok := b["expires_in"].(int); ok {
+	if e, ok := b["expires_in"].(float64); ok {
 		token.Expiry = time.Now().Add(time.Duration(e) * time.Second)
 	}
 	if idtoken, ok := b["id_token"].(string); ok {


### PR DESCRIPTION
As described in the JSON unmarshalling [documentation](http://golang.org/pkg/encoding/json/#Unmarshal), JSON numbers are unmarshalled to float64 interface values.

In the JWT implementation we have a type assertion for `int` after unmarshalling the "expires_in" JSON number, which means the assignment to `token.Expiry` is unreachable. The token is then incorrectly believed to never expire.

I've changed the type assertion to `float64` and added a test case for unmarshalling "expires_in" fields correctly.
