### PR TITLE
Only set client_id in post body when also setting client_secret.

### DIFF
--- a/oauth2.go
+++ b/oauth2.go
@@ -274,9 +274,9 @@ func retrieveToken(ctx Context, c *Config, v url.Values) (*Token, error) {
 	if err != nil {
 		return nil, err
 	}
-	v.Set("client_id", c.ClientID)
 	bustedAuth := !providerAuthHeaderWorks(c.Endpoint.TokenURL)
 	if bustedAuth && c.ClientSecret != "" {
+		v.Set("client_id", c.ClientID)
 		v.Set("client_secret", c.ClientSecret)
 	}
 	req, err := http.NewRequest("POST", c.Endpoint.TokenURL, strings.NewReader(v.Encode()))


### PR DESCRIPTION
The [Blizzard oAuth2 implementation](https://dev.battle.net/docs/read/oauth) will not respect basic auth when there is a client_id present in the post body, causing requests to 401 even when credentials are correct in basic auth.