### PR TITLE
oauth2: add clientID check to bad OAuth2 flow in retrieveToken

### DIFF
--- a/oauth2.go
+++ b/oauth2.go
@@ -316,7 +316,7 @@ func retrieveToken(ctx Context, c *Config, v url.Values) (*Token, error) {
 		return nil, err
 	}
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
-	if !bustedAuth && c.ClientSecret != "" {
+	if !bustedAuth && (c.ClientSecret != "" || c.ClientID != "") {
 		req.SetBasicAuth(c.ClientID, c.ClientSecret)
 	}
 	r, err := hc.Do(req)


### PR DESCRIPTION
Since the req.SetBasicAuth will use both clientID and ClientSecret,
it make sense for us to check both of them.

Signed-off-by: Hu Keping <hukeping@huawei.com>