### PR TITLE
Add Box as a broken oauth provider

### DIFF
--- a/oauth2.go
+++ b/oauth2.go
@@ -437,6 +437,7 @@ var brokenAuthHeaderProviders = []string{
 	"https://oauth.sandbox.trainingpeaks.com/",
 	"https://oauth.trainingpeaks.com/",
 	"https://www.strava.com/oauth/",
+	"https://app.box.com/api/oauth2/token",
 }
 
 // providerAuthHeaderWorks reports whether the OAuth2 server identified by the tokenURL


### PR DESCRIPTION
Box requests to have the `client_secret` as part of the URL parameters, hence candidate for `brokenAuthHeaderProviders` list.