### PR TITLE
Correct RFC 6749 implementation (fixes #145)

### DIFF
--- a/clientcredentials/clientcredentials_test.go
+++ b/clientcredentials/clientcredentials_test.go
@@ -49,8 +49,8 @@ func TestTokenRequest(t *testing.T) {
 		if err != nil {
 			t.Errorf("failed reading request body: %s.", err)
 		}
-		if string(body) != "client_id=CLIENT_ID&grant_type=client_credentials&scope=scope1+scope2" {
-			t.Errorf("payload = %q; want %q", string(body), "client_id=CLIENT_ID&grant_type=client_credentials&scope=scope1+scope2")
+		if string(body) != "grant_type=client_credentials&scope=scope1+scope2" {
+			t.Errorf("payload = %q; want %q", string(body), "grant_type=client_credentials&scope=scope1+scope2")
 		}
 		w.Header().Set("Content-Type", "application/x-www-form-urlencoded")
 		w.Write([]byte("access_token=90d64460d14870c08c81352a05dedd3465940a7c&token_type=bearer"))
@@ -85,7 +85,7 @@ func TestTokenRefreshRequest(t *testing.T) {
 			t.Errorf("Unexpected Content-Type header, %v is found.", headerContentType)
 		}
 		body, _ := ioutil.ReadAll(r.Body)
-		if string(body) != "client_id=CLIENT_ID&grant_type=client_credentials&scope=scope1+scope2" {
+		if string(body) != "grant_type=client_credentials&scope=scope1+scope2" {
 			t.Errorf("Unexpected refresh token payload, %v is found.", string(body))
 		}
 	}))

--- a/internal/token.go
+++ b/internal/token.go
@@ -140,9 +140,9 @@ func RetrieveToken(ctx context.Context, ClientID, ClientSecret, TokenURL string,
 	if err != nil {
 		return nil, err
 	}
-	v.Set("client_id", ClientID)
 	bustedAuth := !providerAuthHeaderWorks(TokenURL)
 	if bustedAuth && ClientSecret != "" {
+		v.Set("client_id", ClientID)
 		v.Set("client_secret", ClientSecret)
 	}
 	req, err := http.NewRequest("POST", TokenURL, strings.NewReader(v.Encode()))

--- a/oauth2.go
+++ b/oauth2.go
@@ -164,7 +164,6 @@ func (c *Config) Exchange(ctx context.Context, code string) (*Token, error) {
 		"grant_type":   {"authorization_code"},
 		"code":         {code},
 		"redirect_uri": internal.CondVal(c.RedirectURL),
-		"scope":        internal.CondVal(strings.Join(c.Scopes, " ")),
 	})
 }
 

--- a/oauth2_test.go
+++ b/oauth2_test.go
@@ -101,7 +101,7 @@ func TestExchangeRequest(t *testing.T) {
 		if err != nil {
 			t.Errorf("Failed reading request body: %s.", err)
 		}
-		if string(body) != "client_id=CLIENT_ID&code=exchange-code&grant_type=authorization_code&redirect_uri=REDIRECT_URL&scope=scope1+scope2" {
+		if string(body) != "code=exchange-code&grant_type=authorization_code&redirect_uri=REDIRECT_URL" {
 			t.Errorf("Unexpected exchange payload, %v is found.", string(body))
 		}
 		w.Header().Set("Content-Type", "application/x-www-form-urlencoded")
@@ -145,7 +145,7 @@ func TestExchangeRequest_JSONResponse(t *testing.T) {
 		if err != nil {
 			t.Errorf("Failed reading request body: %s.", err)
 		}
-		if string(body) != "client_id=CLIENT_ID&code=exchange-code&grant_type=authorization_code&redirect_uri=REDIRECT_URL&scope=scope1+scope2" {
+		if string(body) != "code=exchange-code&grant_type=authorization_code&redirect_uri=REDIRECT_URL" {
 			t.Errorf("Unexpected exchange payload, %v is found.", string(body))
 		}
 		w.Header().Set("Content-Type", "application/json")
@@ -299,7 +299,7 @@ func TestPasswordCredentialsTokenRequest(t *testing.T) {
 		if err != nil {
 			t.Errorf("Failed reading request body: %s.", err)
 		}
-		expected = "client_id=CLIENT_ID&grant_type=password&password=password1&scope=scope1+scope2&username=user1"
+		expected = "grant_type=password&password=password1&scope=scope1+scope2&username=user1"
 		if string(body) != expected {
 			t.Errorf("res.Body = %q; want %q", string(body), expected)
 		}
@@ -338,7 +338,7 @@ func TestTokenRefreshRequest(t *testing.T) {
 			t.Errorf("Unexpected Content-Type header, %v is found.", headerContentType)
 		}
 		body, _ := ioutil.ReadAll(r.Body)
-		if string(body) != "client_id=CLIENT_ID&grant_type=refresh_token&refresh_token=REFRESH_TOKEN" {
+		if string(body) != "grant_type=refresh_token&refresh_token=REFRESH_TOKEN" {
 			t.Errorf("Unexpected refresh token payload, %v is found.", string(body))
 		}
 	}))


### PR DESCRIPTION
Remove "scope" & "client_id" from "token request" in the
"authorization code grant" flow, while keeping "client_id"
in case the provider is one of the known to be broken ones.

This PR fixes #145 