### PR TITLE
Remove GitHub from "broken auth header providers" list

### DIFF
--- a/internal/token.go
+++ b/internal/token.go
@@ -92,7 +92,6 @@ func (e *expirationTime) UnmarshalJSON(b []byte) error {
 var brokenAuthHeaderProviders = []string{
 	"https://accounts.google.com/",
 	"https://www.googleapis.com/",
-	"https://github.com/",
 	"https://api.instagram.com/",
 	"https://www.douban.com/",
 	"https://api.dropbox.com/",


### PR DESCRIPTION
I know this project doesn't do pull requests, but I don't do Gerrit. :grinning: 

I wanted to let you know GitHub now supports passing client credentials over Basic Auth when exchanging the code for a token so you can remove us from the Array O' Shame. :sunglasses: 