### PR TITLE
Add Feedly to the brokenAuthHeaderProviders slice

### DIFF
--- a/internal/token.go
+++ b/internal/token.go
@@ -110,6 +110,8 @@ var brokenAuthHeaderProviders = []string{
 	"https://user.gini.net/",
 	"https://api.netatmo.net/",
 	"https://slack.com/",
+	"https://sandbox.feedly.com/",
+	"https://cloud.feedly.com/",
 }
 
 // providerAuthHeaderWorks reports whether the OAuth2 server identified by the tokenURL


### PR DESCRIPTION
Feedly needs a client_secret to retrieve the oauth token