### PR TITLE
internal: added api.dropboxapi.com to borken providers

### DIFF
--- a/internal/token.go
+++ b/internal/token.go
@@ -92,6 +92,7 @@ func (e *expirationTime) UnmarshalJSON(b []byte) error {
 var brokenAuthHeaderProviders = []string{
 	"https://accounts.google.com/",
 	"https://api.dropbox.com/",
+	"https://api.dropboxapi.com/",
 	"https://api.instagram.com/",
 	"https://api.netatmo.net/",
 	"https://api.odnoklassniki.ru/",


### PR DESCRIPTION
As mentioned in the docs at https://www.dropbox.com/developers-v1/core/docs#oa2-authorize dropbox api now also aliases to api.dropboxapi.com. The old api.dropbox.com endpoint still works, but it looks like dropbox wants to establish dropboxapi.com for api calls.