### PR TITLE
fix Wunderlist api usage

### DIFF
--- a/internal/token.go
+++ b/internal/token.go
@@ -114,6 +114,7 @@ var brokenAuthHeaderProviders = []string{
 	"https://www.googleapis.com/",
 	"https://www.linkedin.com/",
 	"https://www.strava.com/oauth/",
+	"https://www.wunderlist.com/oauth/"
 }
 
 func RegisterBrokenAuthHeaderProvider(tokenURL string) {


### PR DESCRIPTION
Wunderlist api needs to send the client_secret when requesting the token, therefore this change is need it to work with it