### PR TITLE
Add api.dropboxapi.com to broken providers

### DIFF
--- a/internal/token.go
+++ b/internal/token.go
@@ -92,6 +92,7 @@ func (e *expirationTime) UnmarshalJSON(b []byte) error {
 var brokenAuthHeaderProviders = []string{
 	"https://accounts.google.com/",
 	"https://api.dropbox.com/",
+	"https://api.dropboxapi.com/",
 	"https://api.instagram.com/",
 	"https://api.netatmo.net/",
 	"https://api.odnoklassniki.ru/",


### PR DESCRIPTION
This is actually the recommended endpoint per the API docs:
https://www.dropbox.com/developers/documentation/http/documentation