### PR TITLE
Make oauth2 go vet clean

### DIFF
--- a/google/jwt_test.go
+++ b/google/jwt_test.go
@@ -82,7 +82,7 @@ func TestJWTAccessTokenSourceFromJSON(t *testing.T) {
 	}
 	var hdr jws.Header
 	if err := json.Unmarshal([]byte(hdrJSON), &hdr); err != nil {
-		t.Fatalf("json.Unmarshal: %v (%q)", err)
+		t.Fatalf("json.Unmarshal: %v (%q)", err, parts[0])
 	}
 
 	if got, want := hdr.KeyID, "268f54e43a1af97cfc71731688434f45aca15c8b"; got != want {

--- a/google/sdk_test.go
+++ b/google/sdk_test.go
@@ -25,7 +25,7 @@ func TestSDKConfig(t *testing.T) {
 		c, err := NewSDKConfig(tt.account)
 		if got, want := err != nil, tt.err; got != want {
 			if !tt.err {
-				t.Errorf("expected no error, got error: %v", tt.err, err)
+				t.Errorf("expected no error, got error: %v", err)
 			} else {
 				t.Errorf("expected error, got none")
 			}

--- a/jwt/example_test.go
+++ b/jwt/example_test.go
@@ -9,7 +9,7 @@ import (
 	"golang.org/x/oauth2/jwt"
 )
 
-func ExampleJWTConfig() {
+func ExampleConfig() {
 	conf := &jwt.Config{
 		Email: "xxx@developer.com",
 		// The contents of your RSA private key or your PEM file

--- a/oauth2.go
+++ b/oauth2.go
@@ -295,7 +295,7 @@ func NewClient(ctx context.Context, src TokenSource) *http.Client {
 	if src == nil {
 		c, err := internal.ContextClient(ctx)
 		if err != nil {
-			return &http.Client{Transport: internal.ErrorTransport{err}}
+			return &http.Client{Transport: internal.ErrorTransport{Err: err}}
 		}
 		return c
 	}


### PR DESCRIPTION
This pull request makes oauth2 clean from go vet's perspective.

This pull request is broken up in to 3 commits, one per directory, in keeping with the commit history of the project. The changes are fairly straightforward.

This is motivated by vendored oauth2 code raising vet warnings in my own project. I fixed the spot causing (oauth2.go) and went ahead and fixed the others in the tree.

```
[srees@aegir]% go tool vet -v .
Checking file oauth2.go
oauth2.go:298: golang.org/x/oauth2/internal.ErrorTransport composite literal uses unkeyed fields
Checking file token.go
Checking file transport.go
Checking file oauth2_test.go
Checking file token_test.go
Checking file transport_test.go
Checking file example_test.go
Checking file bitbucket/bitbucket.go
Checking file clientcredentials/clientcredentials.go
Checking file clientcredentials/clientcredentials_test.go
Checking file facebook/facebook.go
Checking file fitbit/fitbit.go
Checking file github/github.go
Checking file google/appengine.go
Checking file google/default.go
Checking file google/google.go
Checking file google/jwt.go
Checking file google/sdk.go
Checking file google/google_test.go
Checking file google/jwt_test.go
google/jwt_test.go:85: missing argument for Fatalf("%q"): format reads arg 2, have only 1 args
Checking file google/sdk_test.go
google/sdk_test.go:28: wrong number of args for format in Errorf call: 1 needed but 2 args
Checking file hipchat/hipchat.go
Checking file internal/oauth2.go
Checking file internal/token.go
Checking file internal/transport.go
Checking file internal/oauth2_test.go
Checking file internal/token_test.go
Checking file internal/transport_test.go
Checking file jws/jws.go
Checking file jws/jws_test.go
Checking file jwt/jwt.go
Checking file jwt/jwt_test.go
Checking file jwt/example_test.go
jwt/example_test.go:12: ExampleJWTConfig refers to unknown identifier: JWTConfig
Checking file linkedin/linkedin.go
Checking file microsoft/microsoft.go
Checking file odnoklassniki/odnoklassniki.go
Checking file paypal/paypal.go
Checking file slack/slack.go
Checking file vk/vk.go
```