### PR TITLE
adds documentation about custom http.Client

### DIFF
--- a/oauth2.go
+++ b/oauth2.go
@@ -291,6 +291,10 @@ var HTTPClient internal.ContextKey
 // NewClient creates an *http.Client from a Context and TokenSource.
 // The returned client is not valid beyond the lifetime of the context.
 //
+// Note, that if a custom *http.Client is provided via the Context it
+// is used only for token acquisition and is not used to configure the
+// *http.Client that is returend from NewClient.
+//
 // As a special case, if src is nil, a non-OAuth2 client is returned
 // using the provided context. This exists to support related OAuth2
 // packages.


### PR DESCRIPTION
After talking with @rakyll on issue #206 I wanted to get this documentation down initially so we could all work on it together. Any changes please let me know.

I think the example code describes the subtle much better than the warning in the documentation.

Cheers!