### PR TITLE
clientcredentials: add optional audience parameter

### DIFF
--- a/clientcredentials/clientcredentials.go
+++ b/clientcredentials/clientcredentials.go
@@ -38,6 +38,9 @@ type Config struct {
 
 	// Scope specifies optional requested permissions.
 	Scopes []string
+
+	// Audience specifies optional audience of the token.
+	Audience string
 }
 
 // Token uses client credentials to retrieve a token.
@@ -79,6 +82,7 @@ func (c *tokenSource) Token() (*oauth2.Token, error) {
 	tk, err := internal.RetrieveToken(c.ctx, c.conf.ClientID, c.conf.ClientSecret, c.conf.TokenURL, url.Values{
 		"grant_type": {"client_credentials"},
 		"scope":      internal.CondVal(strings.Join(c.conf.Scopes, " ")),
+		"audience":   internal.CondVal(c.conf.Audience),
 	})
 	if err != nil {
 		return nil, err

--- a/clientcredentials/clientcredentials_test.go
+++ b/clientcredentials/clientcredentials_test.go
@@ -18,6 +18,7 @@ func newConf(url string) *Config {
 		ClientSecret: "CLIENT_SECRET",
 		Scopes:       []string{"scope1", "scope2"},
 		TokenURL:     url + "/token",
+		Audience:     "audience1",
 	}
 }
 
@@ -48,7 +49,7 @@ func TestTokenRequest(t *testing.T) {
 		if err != nil {
 			t.Errorf("failed reading request body: %s.", err)
 		}
-		if string(body) != "grant_type=client_credentials&scope=scope1+scope2" {
+		if string(body) != "audience=audience1&grant_type=client_credentials&scope=scope1+scope2" {
 			t.Errorf("payload = %q; want %q", string(body), "grant_type=client_credentials&scope=scope1+scope2")
 		}
 		w.Header().Set("Content-Type", "application/x-www-form-urlencoded")
@@ -84,7 +85,7 @@ func TestTokenRefreshRequest(t *testing.T) {
 			t.Errorf("Unexpected Content-Type header, %v is found.", headerContentType)
 		}
 		body, _ := ioutil.ReadAll(r.Body)
-		if string(body) != "grant_type=client_credentials&scope=scope1+scope2" {
+		if string(body) != "audience=audience1&grant_type=client_credentials&scope=scope1+scope2" {
 			t.Errorf("Unexpected refresh token payload, %v is found.", string(body))
 		}
 	}))


### PR DESCRIPTION
This is to support https://auth0.com/docs/api-auth/config/asking-for-access-tokens.

Is it okay to add the specific `audience` field or would it be better to allow a map of additional parameters?

Is the doc comment for `Audience` okay?