### PR TITLE
Adds sipgate v1 api to brokenAuthHeaderProviders

### DIFF
--- a/internal/token.go
+++ b/internal/token.go
@@ -120,6 +120,7 @@ var brokenAuthHeaderProviders = []string{
 	"https://www.wunderlist.com/oauth/",
 	"https://api.patreon.com/",
 	"https://sandbox.codeswholesale.com/oauth/token",
+	"https://api.sipgate.com/v1/authorization/oauth",
 }
 
 // brokenAuthHeaderDomains lists broken providers that issue dynamic endpoints.


### PR DESCRIPTION
according to the documentation (https://api.sipgate.com/doc/#!/authorization/createOauthAccessToken), `client_id` and `client_secret` must be provided in the request.