### PR TITLE
Add Okta emea realm to the list of broken providers

### DIFF
--- a/internal/token.go
+++ b/internal/token.go
@@ -129,6 +129,7 @@ var brokenAuthHeaderDomains = []string{
 	".myshopify.com",
 	".okta.com",
 	".oktapreview.com",
+	".okta-emea.com",
 }
 
 func RegisterBrokenAuthHeaderProvider(tokenURL string) {


### PR DESCRIPTION
Okta also runs servers at addresses matching the pattern `.okta-emea.com` .