### PR TITLE
Use provided context in subsequent request

### DIFF
--- a/internal/token.go
+++ b/internal/token.go
@@ -188,6 +188,9 @@ func RetrieveToken(ctx context.Context, clientID, clientSecret, tokenURL string,
 	if !bustedAuth {
 		req.SetBasicAuth(clientID, clientSecret)
 	}
+	if ctx != nil {
+		req = req.WithContext(ctx)
+	}
 	r, err := hc.Do(req)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Currently the HTTP request does not set the given context.
This change sets the context (if not nil) on the request.