### PR TITLE
Added cilogon.org as a broken auth provider

### DIFF
--- a/internal/token.go
+++ b/internal/token.go
@@ -123,6 +123,7 @@ var brokenAuthHeaderProviders = []string{
 	"https://api.patreon.com/",
 	"https://sandbox.codeswholesale.com/oauth/token",
 	"https://api.sipgate.com/v1/authorization/oauth",
+	"https://cilogon.org",
 }
 
 // brokenAuthHeaderDomains lists broken providers that issue dynamic endpoints.


### PR DESCRIPTION
Requires client_id and client_secret in request fields