### PR TITLE
internal: recognize Okta EMEA domains as broken providers

### DIFF
--- a/internal/token.go
+++ b/internal/token.go
@@ -130,6 +130,7 @@ var brokenAuthHeaderDomains = []string{
 	".force.com",
 	".myshopify.com",
 	".okta.com",
+	".okta-emea.com",
 	".oktapreview.com",
 }
 

--- a/internal/token_test.go
+++ b/internal/token_test.go
@@ -65,6 +65,7 @@ func TestProviderAuthHeaderWorksDomain(t *testing.T) {
 		wantWorks bool
 	}{
 		{"https://dev-12345.okta.com/token-url", false},
+		{"https://dev-12345.okta-emea.com/token-url", false},
 		{"https://dev-12345.oktapreview.com/token-url", false},
 		{"https://dev-12345.okta.org/token-url", true},
 		{"https://foo.bar.force.com/token-url", false},


### PR DESCRIPTION
For the EMEA region Okta hands out OAuth endpoints under `okta-emea.com`. This PR adds the url to the brokenAuthHeaderDomains.