### PR TITLE
Pass private claims into JWTAccessTokenSourceFromJSON

### DIFF
--- a/google/jwt.go
+++ b/google/jwt.go
@@ -23,7 +23,7 @@ import (
 // Note that this is not a standard OAuth flow, but rather an
 // optimization supported by a few Google services.
 // Unless you know otherwise, you should use JWTConfigFromJSON instead.
-func JWTAccessTokenSourceFromJSON(jsonKey []byte, audience string) (oauth2.TokenSource, error) {
+func JWTAccessTokenSourceFromJSON(jsonKey []byte, audience string, privateClaims map[string]interface{}) (oauth2.TokenSource, error) {
 	cfg, err := JWTConfigFromJSON(jsonKey)
 	if err != nil {
 		return nil, fmt.Errorf("google: could not parse JSON key: %v", err)
@@ -37,6 +37,7 @@ func JWTAccessTokenSourceFromJSON(jsonKey []byte, audience string) (oauth2.Token
 		audience: audience,
 		pk:       pk,
 		pkID:     cfg.PrivateKeyID,
+		privateClaims: privateClaims,
 	}
 	tok, err := ts.Token()
 	if err != nil {
@@ -49,6 +50,7 @@ type jwtAccessTokenSource struct {
 	email, audience string
 	pk              *rsa.PrivateKey
 	pkID            string
+	privateClaims map[string]interface{}
 }
 
 func (ts *jwtAccessTokenSource) Token() (*oauth2.Token, error) {
@@ -60,6 +62,7 @@ func (ts *jwtAccessTokenSource) Token() (*oauth2.Token, error) {
 		Aud: ts.audience,
 		Iat: iat.Unix(),
 		Exp: exp.Unix(),
+		PrivateClaims: ts.privateClaims,
 	}
 	hdr := &jws.Header{
 		Algorithm: "RS256",


### PR DESCRIPTION
 ```golang
//example usage
privateClaims := map[string]interface{}{"target_audience": "https://api.<PROJECT>.com/"}
tokenSource, _ := google.JWTAccessTokenSourceFromJSON(data, "https://www.googleapis.com/oauth2/v4/token", privateClaims)
```

## Use cases:
A target audience must be specified when exchanging a service account signed token for a Google ID token ([see corresponding Cloud Endpoints documentation](https://cloud.google.com/endpoints/docs/openapi/service-account-authentication#using_a_google_id_token)).

Creating **custom** tokens signed by a service account.