### PR TITLE
Pass private claims into JWTAccessTokenSourceFromJSON

### DIFF
--- a/google/doc_go19.go
+++ b/google/doc_go19.go
@@ -39,4 +39,4 @@
 // same as the one obtained from the oauth2.Config returned from ConfigFromJSON or
 // JWTConfigFromJSON, but the Credentials may contain additional information
 // that is useful is some circumstances.
-package google // import "golang.org/x/oauth2/google"
+package google

--- a/google/doc_not_go19.go
+++ b/google/doc_not_go19.go
@@ -40,4 +40,4 @@
 // is the same as the one obtained from the oauth2.Config returned from
 // ConfigFromJSON or JWTConfigFromJSON, but the DefaultCredentials may contain
 // additional information that is useful is some circumstances.
-package google // import "golang.org/x/oauth2/google"
+package google 

--- a/google/jwt.go
+++ b/google/jwt.go
@@ -23,7 +23,7 @@ import (
 // Note that this is not a standard OAuth flow, but rather an
 // optimization supported by a few Google services.
 // Unless you know otherwise, you should use JWTConfigFromJSON instead.
-func JWTAccessTokenSourceFromJSON(jsonKey []byte, audience string) (oauth2.TokenSource, error) {
+func JWTAccessTokenSourceFromJSON(jsonKey []byte, audience string, privateClaims map[string]interface{}) (oauth2.TokenSource, error) {
 	cfg, err := JWTConfigFromJSON(jsonKey)
 	if err != nil {
 		return nil, fmt.Errorf("google: could not parse JSON key: %v", err)
@@ -37,6 +37,7 @@ func JWTAccessTokenSourceFromJSON(jsonKey []byte, audience string) (oauth2.Token
 		audience: audience,
 		pk:       pk,
 		pkID:     cfg.PrivateKeyID,
+		privateClaims: privateClaims,
 	}
 	tok, err := ts.Token()
 	if err != nil {
@@ -49,6 +50,7 @@ type jwtAccessTokenSource struct {
 	email, audience string
 	pk              *rsa.PrivateKey
 	pkID            string
+	privateClaims map[string]interface{}
 }
 
 func (ts *jwtAccessTokenSource) Token() (*oauth2.Token, error) {
@@ -60,6 +62,7 @@ func (ts *jwtAccessTokenSource) Token() (*oauth2.Token, error) {
 		Aud: ts.audience,
 		Iat: iat.Unix(),
 		Exp: exp.Unix(),
+		PrivateClaims: ts.privateClaims,
 	}
 	hdr := &jws.Header{
 		Algorithm: "RS256",

--- a/google/jwt.go
+++ b/google/jwt.go
@@ -10,7 +10,7 @@ import (
 	"time"
 
 	"golang.org/x/oauth2"
-	"golang.org/x/oauth2/internal"
+	"github.com/tensortask/oauth2/internal"
 	"golang.org/x/oauth2/jws"
 )
 

--- a/google/jwt_test.go
+++ b/google/jwt_test.go
@@ -89,3 +89,90 @@ func TestJWTAccessTokenSourceFromJSON(t *testing.T) {
 		t.Errorf("Header KeyID = %q, want %q", got, want)
 	}
 }
+
+func TestJWTAccessTokenSourceFromJSONWithPrivateClaims(t *testing.T) {
+	// Generate a key we can use in the test data.
+	privateKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Encode the key and substitute into our example JSON.
+	enc := pem.EncodeToMemory(&pem.Block{
+		Type:  "PRIVATE KEY",
+		Bytes: x509.MarshalPKCS1PrivateKey(privateKey),
+	})
+	enc, err = json.Marshal(string(enc))
+	if err != nil {
+		t.Fatalf("json.Marshal: %v", err)
+	}
+	jsonKey := bytes.Replace(jwtJSONKey, []byte(`"super secret key"`), enc, 1)
+
+	privateClaims := map[string]interface{}{"test_claim": "https://golang.org"}
+
+	ts, err := JWTAccessTokenSourceFromJSONWithPrivateClaims(jsonKey, "audience", privateClaims)
+	if err != nil {
+		t.Fatalf("JWTAccessTokenSourceFromJSON: %v\nJSON: %s", err, string(jsonKey))
+	}
+
+	tok, err := ts.Token()
+	if err != nil {
+		t.Fatalf("Token: %v", err)
+	}
+
+	if got, want := tok.TokenType, "Bearer"; got != want {
+		t.Errorf("TokenType = %q, want %q", got, want)
+	}
+	if got := tok.Expiry; tok.Expiry.Before(time.Now()) {
+		t.Errorf("Expiry = %v, should not be expired", got)
+	}
+
+	err = jws.Verify(tok.AccessToken, &privateKey.PublicKey)
+	if err != nil {
+		t.Errorf("jws.Verify on AccessToken: %v", err)
+	}
+
+	claim, err := jws.Decode(tok.AccessToken)
+	if err != nil {
+		t.Fatalf("jws.Decode on AccessToken: %v", err)
+	}
+
+	if got, want := claim.Iss, "gopher@developer.gserviceaccount.com"; got != want {
+		t.Errorf("Iss = %q, want %q", got, want)
+	}
+	if got, want := claim.Sub, "gopher@developer.gserviceaccount.com"; got != want {
+		t.Errorf("Sub = %q, want %q", got, want)
+	}
+	if got, want := claim.Aud, "audience"; got != want {
+		t.Errorf("Aud = %q, want %q", got, want)
+	}
+	// jws.Decode does not handle decoding private claims
+	// https://github.com/golang/oauth2/blob/master/jws/jws.go#L54
+
+	// Finally, check the header private key.
+	parts := strings.Split(tok.AccessToken, ".")
+	hdrJSON, err := base64.RawURLEncoding.DecodeString(parts[0])
+	if err != nil {
+		t.Fatalf("base64 DecodeString: %v\nString: %q", err, parts[0])
+	}
+
+	payloadJSON, err := base64.RawURLEncoding.DecodeString(parts[1])
+	if err != nil {
+		t.Fatalf("base64 DecodeString: %v\nString: %q", err, parts[0])
+	}
+
+	containsPrivateClaim := strings.Contains(string(payloadJSON), "test_claim")
+
+	if got, want := containsPrivateClaim, true; got != want {
+		t.Errorf("got private claims: %v, want private claims: %v", got, want)
+	}
+
+	var hdr jws.Header
+	if err := json.Unmarshal([]byte(hdrJSON), &hdr); err != nil {
+		t.Fatalf("json.Unmarshal: %v (%q)", err, hdrJSON)
+	}
+
+	if got, want := hdr.KeyID, "268f54e43a1af97cfc71731688434f45aca15c8b"; got != want {
+		t.Errorf("Header KeyID = %q, want %q", got, want)
+	}
+}

--- a/jws/jws.go
+++ b/jws/jws.go
@@ -12,7 +12,7 @@
 // removed in the future. It exists for internal use only.
 // Please switch to another JWS package or copy this package into your own
 // source tree.
-package jws // import "golang.org/x/oauth2/jws"
+package jws 
 
 import (
 	"bytes"


### PR DESCRIPTION
# Revised

 ```golang
//example usage
privateClaims := map[string]interface{}{"target_audience": "https://api.<PROJECT>.com/"}
tokenSource, _ := google.JWTAccessTokenSourceFromJSON(data, "https://www.googleapis.com/oauth2/v4/token", privateClaims)
```

### Use cases:
A target audience must be specified when exchanging a service account signed token for a Google ID token ([see corresponding Cloud Endpoints documentation](https://cloud.google.com/endpoints/docs/openapi/service-account-authentication#using_a_google_id_token)).

Creating **custom** tokens signed by a service account.