### PR TITLE
oauth2/google: sign private claims with service account

### DIFF
--- a/google/jwt.go
+++ b/google/jwt.go
@@ -45,6 +45,17 @@ func JWTAccessTokenSourceFromJSON(jsonKey []byte, audience string) (oauth2.Token
 	return oauth2.ReuseTokenSource(tok, ts), nil
 }
 
+// JWTAccessTokenSourceFromJSONWithPrivateClaims uses a Google Developers service
+// account JSON key file to read the credentials that authorize and authenticate
+// the requests, and returns a TokenSource that does not use any OAuth2 flow but
+// instead creates a JWT and sends that as the access token.
+//
+// Unlike JWTAccessTokenSourceFromJSON, JWTAccessTokenSourceFromJSONWithPrivateClaims
+// has an additional argument for passing private claims into the generated token.
+// This is helpful when exchanging a service account signed token for a
+// Google ID token.
+//
+// Unless you know otherwise, you should use JWTConfigFromJSON.
 func JWTAccessTokenSourceFromJSONWithPrivateClaims(jsonKey []byte, audience string, privateClaims map[string]interface{}) (oauth2.TokenSource, error) {
 	cfg, err := JWTConfigFromJSON(jsonKey)
 	if err != nil {

--- a/google/jwt.go
+++ b/google/jwt.go
@@ -23,7 +23,7 @@ import (
 // Note that this is not a standard OAuth flow, but rather an
 // optimization supported by a few Google services.
 // Unless you know otherwise, you should use JWTConfigFromJSON instead.
-func JWTAccessTokenSourceFromJSON(jsonKey []byte, audience string) (oauth2.TokenSource, error) {
+func JWTAccessTokenSourceFromJSON(jsonKey []byte, audience string, privateClaims map[string]interface{}) (oauth2.TokenSource, error) {
 	cfg, err := JWTConfigFromJSON(jsonKey)
 	if err != nil {
 		return nil, fmt.Errorf("google: could not parse JSON key: %v", err)
@@ -37,6 +37,7 @@ func JWTAccessTokenSourceFromJSON(jsonKey []byte, audience string) (oauth2.Token
 		audience: audience,
 		pk:       pk,
 		pkID:     cfg.PrivateKeyID,
+		privateClaims: privateClaims,
 	}
 	tok, err := ts.Token()
 	if err != nil {
@@ -49,6 +50,7 @@ type jwtAccessTokenSource struct {
 	email, audience string
 	pk              *rsa.PrivateKey
 	pkID            string
+	privateClaims map[string]interface{}
 }
 
 func (ts *jwtAccessTokenSource) Token() (*oauth2.Token, error) {
@@ -60,6 +62,7 @@ func (ts *jwtAccessTokenSource) Token() (*oauth2.Token, error) {
 		Aud: ts.audience,
 		Iat: iat.Unix(),
 		Exp: exp.Unix(),
+		PrivateClaims: ts.privateClaims,
 	}
 	hdr := &jws.Header{
 		Algorithm: "RS256",

--- a/google/jwt_test.go
+++ b/google/jwt_test.go
@@ -89,3 +89,90 @@ func TestJWTAccessTokenSourceFromJSON(t *testing.T) {
 		t.Errorf("Header KeyID = %q, want %q", got, want)
 	}
 }
+
+func TestJWTAccessTokenSourceFromJSONWithPrivateClaims(t *testing.T) {
+	// Generate a key we can use in the test data.
+	privateKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Encode the key and substitute into our example JSON.
+	enc := pem.EncodeToMemory(&pem.Block{
+		Type:  "PRIVATE KEY",
+		Bytes: x509.MarshalPKCS1PrivateKey(privateKey),
+	})
+	enc, err = json.Marshal(string(enc))
+	if err != nil {
+		t.Fatalf("json.Marshal: %v", err)
+	}
+	jsonKey := bytes.Replace(jwtJSONKey, []byte(`"super secret key"`), enc, 1)
+
+	privateClaims := map[string]interface{}{"test_claim": "https://golang.org"}
+
+	ts, err := JWTAccessTokenSourceFromJSONWithPrivateClaims(jsonKey, "audience", privateClaims)
+	if err != nil {
+		t.Fatalf("JWTAccessTokenSourceFromJSON: %v\nJSON: %s", err, string(jsonKey))
+	}
+
+	tok, err := ts.Token()
+	if err != nil {
+		t.Fatalf("Token: %v", err)
+	}
+
+	if got, want := tok.TokenType, "Bearer"; got != want {
+		t.Errorf("TokenType = %q, want %q", got, want)
+	}
+	if got := tok.Expiry; tok.Expiry.Before(time.Now()) {
+		t.Errorf("Expiry = %v, should not be expired", got)
+	}
+
+	err = jws.Verify(tok.AccessToken, &privateKey.PublicKey)
+	if err != nil {
+		t.Errorf("jws.Verify on AccessToken: %v", err)
+	}
+
+	claim, err := jws.Decode(tok.AccessToken)
+	if err != nil {
+		t.Fatalf("jws.Decode on AccessToken: %v", err)
+	}
+
+	if got, want := claim.Iss, "gopher@developer.gserviceaccount.com"; got != want {
+		t.Errorf("Iss = %q, want %q", got, want)
+	}
+	if got, want := claim.Sub, "gopher@developer.gserviceaccount.com"; got != want {
+		t.Errorf("Sub = %q, want %q", got, want)
+	}
+	if got, want := claim.Aud, "audience"; got != want {
+		t.Errorf("Aud = %q, want %q", got, want)
+	}
+	// jws.Decode does not handle decoding private claims
+	// https://github.com/golang/oauth2/blob/master/jws/jws.go#L54
+
+	// Finally, check the header private key.
+	parts := strings.Split(tok.AccessToken, ".")
+	hdrJSON, err := base64.RawURLEncoding.DecodeString(parts[0])
+	if err != nil {
+		t.Fatalf("base64 DecodeString: %v\nString: %q", err, parts[0])
+	}
+
+	payloadJSON, err := base64.RawURLEncoding.DecodeString(parts[1])
+	if err != nil {
+		t.Fatalf("base64 DecodeString: %v\nString: %q", err, parts[0])
+	}
+
+	containsPrivateClaim := strings.Contains(string(payloadJSON), "test_claim")
+
+	if got, want := containsPrivateClaim, true; got != want {
+		t.Errorf("got private claims: %v, want private claims: %v", got, want)
+	}
+
+	var hdr jws.Header
+	if err := json.Unmarshal([]byte(hdrJSON), &hdr); err != nil {
+		t.Fatalf("json.Unmarshal: %v (%q)", err, hdrJSON)
+	}
+
+	if got, want := hdr.KeyID, "268f54e43a1af97cfc71731688434f45aca15c8b"; got != want {
+		t.Errorf("Header KeyID = %q, want %q", got, want)
+	}
+}


### PR DESCRIPTION
In some cases it is desirable to generate a JWT signed by a service
account with custom claims. For instance, when exchanging a service
account signed token for a Google ID token.

Fixes golang/oauth2#266