### PR TITLE
Correct box.com API domain, which still doesn't support Authorization header

### DIFF
--- a/internal/token.go
+++ b/internal/token.go
@@ -102,6 +102,7 @@ var brokenAuthHeaderProviders = []string{
 	"https://api.soundcloud.com/",
 	"https://api.twitch.tv/",
 	"https://id.twitch.tv/",
+	"https://app.box.com/",
 	"https://api.box.com/",
 	"https://connect.stripe.com/",
 	"https://login.mailchimp.com/",

--- a/internal/token.go
+++ b/internal/token.go
@@ -102,7 +102,7 @@ var brokenAuthHeaderProviders = []string{
 	"https://api.soundcloud.com/",
 	"https://api.twitch.tv/",
 	"https://id.twitch.tv/",
-	"https://app.box.com/",
+	"https://api.box.com/",
 	"https://connect.stripe.com/",
 	"https://login.mailchimp.com/",
 	"https://login.microsoftonline.com/",


### PR DESCRIPTION
Box.com OAuth authorization fails stating "invalid client credentials". Correct API domain is "api.box.com" (source: https://developer.box.com/reference#token)