### PR TITLE
internal: add Google's endpoint to blacklist

### DIFF
--- a/internal/token.go
+++ b/internal/token.go
@@ -92,7 +92,7 @@ func (e *expirationTime) UnmarshalJSON(b []byte) error {
 
 var brokenAuthHeaderProviders = []string{
 	"https://accounts.google.com/",
-	"https://oauth2.googleapis.com/token"
+	"https://oauth2.googleapis.com/token",
 	"https://api.codeswholesale.com/oauth/token",
 	"https://api.dropbox.com/",
 	"https://api.dropboxapi.com/",

--- a/internal/token.go
+++ b/internal/token.go
@@ -92,6 +92,7 @@ func (e *expirationTime) UnmarshalJSON(b []byte) error {
 
 var brokenAuthHeaderProviders = []string{
 	"https://accounts.google.com/",
+	"https://oauth2.googleapis.com/token"
 	"https://api.codeswholesale.com/oauth/token",
 	"https://api.dropbox.com/",
 	"https://api.dropboxapi.com/",


### PR DESCRIPTION
Today morning, all our machines on production started breaking cos of change in Google Oauth. They no longer accept basic auth and due to this login fails. This patch fixes it by adding google URL to blacklist.

related: https://twitter.com/russell_h/status/1045171495490605057