### PR TITLE
internal: recognize "oauth2.googleapis.com" as a broken auth header d…

### DIFF
--- a/internal/token.go
+++ b/internal/token.go
@@ -116,7 +116,6 @@ var brokenAuthHeaderProviders = []string{
 	"https://test.salesforce.com/",
 	"https://user.gini.net/",
 	"https://www.douban.com/",
-	"https://www.googleapis.com/",
 	"https://www.linkedin.com/",
 	"https://www.strava.com/oauth/",
 	"https://www.wunderlist.com/oauth/",
@@ -131,6 +130,7 @@ var brokenAuthHeaderProviders = []string{
 var brokenAuthHeaderDomains = []string{
 	".auth0.com",
 	".force.com",
+	".googleapis.com",
 	".myshopify.com",
 	".okta.com",
 	".oktapreview.com",

--- a/internal/token_test.go
+++ b/internal/token_test.go
@@ -72,6 +72,8 @@ func TestProviderAuthHeaderWorksDomain(t *testing.T) {
 		{"https://foo.bar.force.com/token-url", false},
 		{"https://foo.force.com/token-url", false},
 		{"https://force.com/token-url", true},
+		{"https://www.googleapis.com", false},
+		{"https://oauth2.googleapis.com", false},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
…omain

Google's OpenID Connect discovery document[1] recently updated its
token endpoint, using "https://oauth2.googleapis.com/token" instead
of the old "https://accounts.google.com/o/oauth2/token". This broke
clients who use that document to discover the token endpoint.[2]

Make this package mark "https://oauth2.googleapis.com" as a domain
that doesn't accept client ID and secret using basic auth.

Users can temporary fix this without pulling in this change by adding
the following init method to their code:

```go
func init() {
    oauth2.RegisterBrokenAuthHeaderProvider("https://oauth2.googleapis.com/token ")
}
```

Tested using https://github.com/coreos/go-oidc/tree/v2/example

[1] https://accounts.google.com/.well-known/openid-configuration
[2] https://twitter.com/russell_h/status/1045171495490605057

cc @russellhaering 