### PR TITLE
Add possibility to replace behavior in RetrieveToken functionality

### DIFF
--- a/clientcredentials/clientcredentials.go
+++ b/clientcredentials/clientcredentials.go
@@ -42,6 +42,9 @@ type Config struct {
 
 	// EndpointParams specifies additional parameters for requests to the token endpoint.
 	EndpointParams url.Values
+
+	// AuthChecker checker broken AuthHeaderProviders
+	AuthChecker func(tokenURL string) bool
 }
 
 // Token uses client credentials to retrieve a token.
@@ -92,7 +95,7 @@ func (c *tokenSource) Token() (*oauth2.Token, error) {
 		}
 		v[k] = p
 	}
-	tk, err := internal.RetrieveToken(c.ctx, c.conf.ClientID, c.conf.ClientSecret, c.conf.TokenURL, v)
+	tk, err := internal.RetrieveToken(c.ctx, c.conf.ClientID, c.conf.ClientSecret, c.conf.TokenURL, c.conf.AuthChecker, v)
 	if err != nil {
 		if rErr, ok := err.(*internal.RetrieveError); ok {
 			return nil, (*oauth2.RetrieveError)(rErr)

--- a/internal/token.go
+++ b/internal/token.go
@@ -178,8 +178,15 @@ func providerAuthHeaderWorks(tokenURL string) bool {
 	return true
 }
 
-func RetrieveToken(ctx context.Context, clientID, clientSecret, tokenURL string, v url.Values) (*Token, error) {
-	bustedAuth := !providerAuthHeaderWorks(tokenURL)
+func RetrieveToken(ctx context.Context, clientID, clientSecret, tokenURL string, checker func(tokenURL string) bool, v url.Values) (*Token, error) {
+	var bustedAuth bool
+
+	if checker != nil {
+		bustedAuth = !checker(tokenURL)
+	} else {
+		bustedAuth = !providerAuthHeaderWorks(tokenURL)
+	}
+
 	if bustedAuth {
 		if clientID != "" {
 			v.Set("client_id", clientID)

--- a/internal/token_test.go
+++ b/internal/token_test.go
@@ -39,7 +39,7 @@ func TestRetrieveTokenBustedNoSecret(t *testing.T) {
 	defer ts.Close()
 
 	RegisterBrokenAuthHeaderProvider(ts.URL)
-	_, err := RetrieveToken(context.Background(), clientID, "", ts.URL, url.Values{})
+	_, err := RetrieveToken(context.Background(), clientID, "", ts.URL, nil, url.Values{})
 	if err != nil {
 		t.Errorf("RetrieveToken = %v; want no error", err)
 	}
@@ -91,7 +91,7 @@ func TestRetrieveTokenWithContexts(t *testing.T) {
 	}))
 	defer ts.Close()
 
-	_, err := RetrieveToken(context.Background(), clientID, "", ts.URL, url.Values{})
+	_, err := RetrieveToken(context.Background(), clientID, "", ts.URL, nil, url.Values{})
 	if err != nil {
 		t.Errorf("RetrieveToken (with background context) = %v; want no error", err)
 	}
@@ -104,7 +104,7 @@ func TestRetrieveTokenWithContexts(t *testing.T) {
 
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
-	_, err = RetrieveToken(ctx, clientID, "", cancellingts.URL, url.Values{})
+	_, err = RetrieveToken(ctx, clientID, "", cancellingts.URL, nil, url.Values{})
 	close(retrieved)
 	if err == nil {
 		t.Errorf("RetrieveToken (with cancelled context) = nil; want error")

--- a/oauth2.go
+++ b/oauth2.go
@@ -61,6 +61,9 @@ type Config struct {
 
 	// Scope specifies optional requested permissions.
 	Scopes []string
+
+	// AuthChecker checker broken AuthHeaderProviders
+	AuthChecker func(tokenURL string) bool
 }
 
 // A TokenSource is anything that can return a token.

--- a/token.go
+++ b/token.go
@@ -151,7 +151,7 @@ func tokenFromInternal(t *internal.Token) *Token {
 // This token is then mapped from *internal.Token into an *oauth2.Token which is returned along
 // with an error..
 func retrieveToken(ctx context.Context, c *Config, v url.Values) (*Token, error) {
-	tk, err := internal.RetrieveToken(ctx, c.ClientID, c.ClientSecret, c.Endpoint.TokenURL, v)
+	tk, err := internal.RetrieveToken(ctx, c.ClientID, c.ClientSecret, c.Endpoint.TokenURL, c.AuthChecker, v)
 	if err != nil {
 		if rErr, ok := err.(*internal.RetrieveError); ok {
 			return nil, (*RetrieveError)(rErr)


### PR DESCRIPTION
In part of RetrieveToken functionality add possibility to replace the
behavior providerAuthHeaderWorks. In this case we can skip
RegisterBrokenAuthHeaderProvider and specify an authorization strategy
**basic auth** with headers or **post auth** with values in body