### PR TITLE
add microsoft sandbox token endpoint

### DIFF
--- a/internal/token.go
+++ b/internal/token.go
@@ -110,6 +110,7 @@ var brokenAuthHeaderProviders = []string{
 	"https://login.salesforce.com/",
 	"https://login.windows.net",
 	"https://login.live.com/",
+	"https://login.live-int.com/",
 	"https://oauth.sandbox.trainingpeaks.com/",
 	"https://oauth.trainingpeaks.com/",
 	"https://oauth.vk.com/",


### PR DESCRIPTION
microsoft is now requiring oauth logins to sandbox accounts for bingads

https://docs.microsoft.com/en-us/bingads/guides/migration-guide?view=bingads-12

the token endpoint is login.live-int.com

https://docs.microsoft.com/en-us/bingads/guides/authentication-oauth?view=bingads-12

