### PR TITLE
google: improve logic for default credentials

### DIFF
--- a/google/go19.go
+++ b/google/go19.go
@@ -37,9 +37,11 @@ type DefaultCredentials = Credentials
 //
 //   1. A JSON file whose path is specified by the
 //      GOOGLE_APPLICATION_CREDENTIALS environment variable.
+//      An error is returned if credentials could not be read.
 //   2. A JSON file in a location known to the gcloud command-line tool.
 //      On Windows, this is %APPDATA%/gcloud/application_default_credentials.json.
 //      On other systems, $HOME/.config/gcloud/application_default_credentials.json.
+//      If this file cannot be read next options are tried.
 //   3. On Google App Engine it uses the appengine.AccessToken function.
 //   4. On Google Compute Engine and Google App Engine Managed VMs, it fetches
 //      credentials from the metadata server.


### PR DESCRIPTION
Documentation states that default credentials are searched from four different places, preferring the first location found. In reality the logic behind that is a bit more complex. If GOOGLE_CREDENTIALS is defined but the file cannot be read an error is returned. This is understandable since it is enforced by the user. However, that is not the case with the second option of reading the credentials from a well-known file. If this implementation is used in an environment where the well-known file path is unaccessible due to file permissions, no GAE or GCE default credentials will be tried. This commit changes that behaviour.

In addition, if well-known file is not accessible and the application is not run on GAE or GCE, an error message will be returned to show why the file could not be accessed. All file related errors will return a descriptive error message, which include a link to the Google documentation. Previously only the "file not found" error included the link, but it is now applied to all well-known-file errors.