### PR TITLE
Add Zoho to the list of broken providers

### DIFF
--- a/internal/token.go
+++ b/internal/token.go
@@ -133,6 +133,7 @@ var brokenAuthHeaderProviders = []string{
 	"https://whats.todaysplan.com.au/rest/oauth/access_token",
 	"https://stackoverflow.com/oauth/access_token",
 	"https://account.health.nokia.com",
+	"https://accounts.zoho.com",
 }
 
 // brokenAuthHeaderDomains lists broken providers that issue dynamic endpoints.


### PR DESCRIPTION
As per the documentation https://www.zoho.com/crm/help/api/v2/#generate-access

The oauth2 implementation for Zoho is broken in other ways as well, e.g. by having scopes comma separated instead of space separated as the standard says. But won't (and shouldn't) be handled by this project as per https://github.com/golang/oauth2/issues/119.