### PR TITLE
all: use stdlib context instead of x/net/context

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,9 @@ See godoc for further documentation and examples.
 
 In change 96e89be (March 2015), we removed the `oauth2.Context2` type in favor
 of the [`context.Context`](https://golang.org/x/net/context#Context) type from
-the `golang.org/x/net/context` package
+the `golang.org/x/net/context` package. Later replaced by the standard `context` package
+of the [`context.Context`](https://golang.org/pkg/context#Context) type.
+
 
 This means it's no longer possible to use the "Classic App Engine"
 `appengine.Context` type with the `oauth2` package. (You're using
@@ -44,7 +46,7 @@ with the `oauth2` package.
 
 ```go
 import (
-	"golang.org/x/net/context"
+	"context"
 	"golang.org/x/oauth2"
 	"golang.org/x/oauth2/google"
 	newappengine "google.golang.org/appengine"

--- a/clientcredentials/clientcredentials.go
+++ b/clientcredentials/clientcredentials.go
@@ -14,12 +14,12 @@
 package clientcredentials // import "golang.org/x/oauth2/clientcredentials"
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"net/url"
 	"strings"
 
-	"golang.org/x/net/context"
 	"golang.org/x/oauth2"
 	"golang.org/x/oauth2/internal"
 )

--- a/google/appengine.go
+++ b/google/appengine.go
@@ -5,12 +5,12 @@
 package google
 
 import (
+	"context"
 	"sort"
 	"strings"
 	"sync"
 	"time"
 
-	"golang.org/x/net/context"
 	"golang.org/x/oauth2"
 )
 

--- a/google/default.go
+++ b/google/default.go
@@ -5,6 +5,7 @@
 package google
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
@@ -14,7 +15,6 @@ import (
 	"runtime"
 
 	"cloud.google.com/go/compute/metadata"
-	"golang.org/x/net/context"
 	"golang.org/x/oauth2"
 )
 

--- a/google/example_test.go
+++ b/google/example_test.go
@@ -5,12 +5,12 @@
 package google_test
 
 import (
+	"context"
 	"fmt"
 	"io/ioutil"
 	"log"
 	"net/http"
 
-	"golang.org/x/net/context"
 	"golang.org/x/oauth2"
 	"golang.org/x/oauth2/google"
 	"golang.org/x/oauth2/jwt"

--- a/google/go19.go
+++ b/google/go19.go
@@ -7,7 +7,8 @@
 package google
 
 import (
-	"golang.org/x/net/context"
+	"context"
+
 	"golang.org/x/oauth2"
 )
 

--- a/google/google.go
+++ b/google/google.go
@@ -5,6 +5,7 @@
 package google
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -12,7 +13,6 @@ import (
 	"time"
 
 	"cloud.google.com/go/compute/metadata"
-	"golang.org/x/net/context"
 	"golang.org/x/oauth2"
 	"golang.org/x/oauth2/jwt"
 )

--- a/google/not_go19.go
+++ b/google/not_go19.go
@@ -7,7 +7,8 @@
 package google
 
 import (
-	"golang.org/x/net/context"
+	"context"
+
 	"golang.org/x/oauth2"
 )
 

--- a/google/sdk.go
+++ b/google/sdk.go
@@ -6,6 +6,7 @@ package google
 
 import (
 	"bufio"
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -18,7 +19,6 @@ import (
 	"strings"
 	"time"
 
-	"golang.org/x/net/context"
 	"golang.org/x/oauth2"
 )
 

--- a/internal/token.go
+++ b/internal/token.go
@@ -5,6 +5,7 @@
 package internal
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -17,7 +18,6 @@ import (
 	"strings"
 	"time"
 
-	"golang.org/x/net/context"
 	"golang.org/x/net/context/ctxhttp"
 )
 

--- a/internal/token_test.go
+++ b/internal/token_test.go
@@ -5,14 +5,13 @@
 package internal
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
 	"testing"
-
-	"golang.org/x/net/context"
 )
 
 func TestRegisterBrokenAuthHeaderProvider(t *testing.T) {

--- a/internal/transport.go
+++ b/internal/transport.go
@@ -5,9 +5,8 @@
 package internal
 
 import (
+	"context"
 	"net/http"
-
-	"golang.org/x/net/context"
 )
 
 // HTTPClient is the context key to use with golang.org/x/net/context's

--- a/jwt/jwt.go
+++ b/jwt/jwt.go
@@ -9,6 +9,7 @@
 package jwt
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -18,7 +19,6 @@ import (
 	"strings"
 	"time"
 
-	"golang.org/x/net/context"
 	"golang.org/x/oauth2"
 	"golang.org/x/oauth2/internal"
 	"golang.org/x/oauth2/jws"

--- a/oauth2.go
+++ b/oauth2.go
@@ -10,13 +10,13 @@ package oauth2 // import "golang.org/x/oauth2"
 
 import (
 	"bytes"
+	"context"
 	"errors"
 	"net/http"
 	"net/url"
 	"strings"
 	"sync"
 
-	"golang.org/x/net/context"
 	"golang.org/x/oauth2/internal"
 )
 

--- a/oauth2_test.go
+++ b/oauth2_test.go
@@ -5,6 +5,7 @@
 package oauth2
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"io/ioutil"
@@ -13,8 +14,6 @@ import (
 	"net/url"
 	"testing"
 	"time"
-
-	"golang.org/x/net/context"
 )
 
 type mockTransport struct {

--- a/token.go
+++ b/token.go
@@ -5,6 +5,7 @@
 package oauth2
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -12,7 +13,6 @@ import (
 	"strings"
 	"time"
 
-	"golang.org/x/net/context"
 	"golang.org/x/oauth2/internal"
 )
 


### PR DESCRIPTION
This PR replaces use of `x/net/context` with the standard `context`
It has been nearly 6 months since https://github.com/golang/oauth2/issues/246#issuecomment-387601277 so I made this PR so it will be ready to merge when needed (and if possible).

Fixes #246