### PR TITLE
FB to be in the list of broken providers

### DIFF
--- a/internal/token.go
+++ b/internal/token.go
@@ -134,6 +134,7 @@ var brokenAuthHeaderProviders = []string{
 	"https://stackoverflow.com/oauth/access_token",
 	"https://account.health.nokia.com",
 	"https://accounts.zoho.com",
+	"https://graph.facebook.com",
 }
 
 // brokenAuthHeaderDomains lists broken providers that issue dynamic endpoints.


### PR DESCRIPTION
Facebook's graph api requires client_id get parameter

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/golang/oauth2/345)
<!-- Reviewable:end -->
