### PR TITLE
internal: add gitter to broken provider list

### DIFF
--- a/internal/token.go
+++ b/internal/token.go
@@ -134,6 +134,7 @@ var brokenAuthHeaderProviders = []string{
 	"https://stackoverflow.com/oauth/access_token",
 	"https://account.health.nokia.com",
 	"https://accounts.zoho.com",
+	"https://gitter.im/login/oauth/token",
 }
 
 // brokenAuthHeaderDomains lists broken providers that issue dynamic endpoints.


### PR DESCRIPTION
Per https://developer.gitter.im/docs/authentication#2-gitter-redirects-back-to-your-site ,
both client_id and client_secret are required request parameters.