### PR TITLE
Add id.adform.com to broken providers list

### DIFF
--- a/internal/token.go
+++ b/internal/token.go
@@ -137,6 +137,7 @@ var brokenAuthHeaderProviders = []string{
 	"https://gitter.im/login/oauth/token",
 	"https://openid-connect.onelogin.com/oidc",
 	"https://api.dailymotion.com/oauth/token",
+	"https://id.adform.com",
 }
 
 // brokenAuthHeaderDomains lists broken providers that issue dynamic endpoints.


### PR DESCRIPTION
Even [id.adform.com](https://id.adform.com) provider supports client credentials passed via Basic auth HTTP header, if the client_id contains special symbols, they are not properly decoded. Adding the provider to the broken auth header providers list to make sure the credentials are passed via body and are parsed correctly.