### PR TITLE
Clarify that client credentials are not passed in the URL

### DIFF
--- a/oauth2.go
+++ b/oauth2.go
@@ -31,7 +31,7 @@ var NoContext = context.TODO()
 // which doesn't support the HTTP Basic authentication
 // scheme to authenticate with the authorization server.
 // Once a server is registered, credentials (client_id and client_secret)
-// will be passed as query parameters rather than being present
+// will be passed as parameters in the request body rather than being present
 // in the Authorization header.
 // See https://code.google.com/p/goauth2/issues/detail?id=31 for background.
 func RegisterBrokenAuthHeaderProvider(tokenURL string) {


### PR DESCRIPTION
The term "query parameters" suggested that the credentials are passed in the URL which is insecure and is actually not true as the credentials are passed in the request body. See https://github.com/golang/oauth2/blob/36a7019397c4c86cf59eeab3bc0d188bac444277/internal/token.go#L196