### PR TITLE
Increase expireDelta time to 60 seconds

### DIFF
--- a/jws/jws.go
+++ b/jws/jws.go
@@ -55,7 +55,7 @@ func (c *ClaimSet) encode() (string, error) {
 	// Reverting time back for machines whose time is not perfectly in sync.
 	// If client machine's time is in the future according
 	// to Google servers, an access token will not be issued.
-	now := time.Now().Add(-10 * time.Second)
+	now := time.Now().Add(-60 * time.Second)
 	if c.Iat == 0 {
 		c.Iat = now.Unix()
 	}

--- a/token.go
+++ b/token.go
@@ -19,7 +19,7 @@ import (
 // expiryDelta determines how earlier a token should be considered
 // expired than its actual expiration time. It is used to avoid late
 // expirations due to client-server time mismatches.
-const expiryDelta = 10 * time.Second
+const expiryDelta = 60 * time.Second
 
 // Token represents the credentials used to authorize
 // the requests to access protected resources on the OAuth 2.0

--- a/token_test.go
+++ b/token_test.go
@@ -42,9 +42,9 @@ func TestTokenExpiry(t *testing.T) {
 		tok  *Token
 		want bool
 	}{
-		{name: "12 seconds", tok: &Token{Expiry: now.Add(12 * time.Second)}, want: false},
-		{name: "10 seconds", tok: &Token{Expiry: now.Add(expiryDelta)}, want: false},
-		{name: "10 seconds-1ns", tok: &Token{Expiry: now.Add(expiryDelta - 1*time.Nanosecond)}, want: true},
+		{name: "62 seconds", tok: &Token{Expiry: now.Add(62 * time.Second)}, want: false},
+		{name: "60 seconds", tok: &Token{Expiry: now.Add(expiryDelta)}, want: false},
+		{name: "60 seconds-1ns", tok: &Token{Expiry: now.Add(expiryDelta - 1*time.Nanosecond)}, want: true},
 		{name: "-1 hour", tok: &Token{Expiry: now.Add(-1 * time.Hour)}, want: true},
 	}
 	for _, tc := range cases {


### PR DESCRIPTION
10 seconds token expire delta is too small as on poor connections one can easily end up with
401 error due to temporary network issues and lengthy TCP/IP retries.
It leads to a rather misleading 401 authorization error.

The issue is observed in real-life with Google Cloud object storage and other services.