### PR TITLE
clientcredentials: allow override of grant_type

### DIFF
--- a/clientcredentials/clientcredentials.go
+++ b/clientcredentials/clientcredentials.go
@@ -90,7 +90,9 @@ func (c *tokenSource) Token() (*oauth2.Token, error) {
 		v.Set("scope", strings.Join(c.conf.Scopes, " "))
 	}
 	for k, p := range c.conf.EndpointParams {
-		if _, ok := v[k]; ok {
+		// Allow grant_type to be overridden to allow interoperability with
+		// non-compliant implementations.
+		if _, ok := v[k]; ok && k != "grant_type" {
 			return nil, fmt.Errorf("oauth2: cannot overwrite parameter %q", k)
 		}
 		v[k] = p


### PR DESCRIPTION
Password-based authentication to the [Keycloak](https://www.keycloak.org/) API requires `grant_type` to be `password`. It would be very helpful if `golang.org/x/oauth2` could be used for this, and all's that missing is the ability to override `grant_type`.

Fixes #283