### PR TITLE
handling for permissions fail on well-known file

### DIFF
--- a/google/default.go
+++ b/google/default.go
@@ -89,7 +89,7 @@ func FindDefaultCredentials(ctx context.Context, scopes ...string) (*Credentials
 	filename := wellKnownFile()
 	if creds, err := readCredentialsFile(ctx, filename, scopes); err == nil {
 		return creds, nil
-	} else if !os.IsNotExist(err) {
+	} else if !(os.IsNotExist(err) || os.IsPermission(err)) {
 		return nil, fmt.Errorf("google: error getting credentials using well-known file (%v): %v", filename, err)
 	}
 


### PR DESCRIPTION
one of our customers has an edge case where sometimes they get an inexplicable permissions error on the well-known file. It's a GCE instance, so it should use the 4th method (line 106+). It never reaches this code as method 2 fails with a permissions error on line 92.