### PR TITLE
Suggestion to add another method for ClientCredentails TokenSource

### DIFF
--- a/clientcredentials/clientcredentials.go
+++ b/clientcredentials/clientcredentials.go
@@ -75,6 +75,17 @@ func (c *Config) TokenSource(ctx context.Context) oauth2.TokenSource {
 	return oauth2.ReuseTokenSource(nil, source)
 }
 
+// TokenSourceWithToken returns a TokenSource that returns t until t expires or until t is set to nil or AccessToken to empty,
+// automatically refreshing it as necessary using the provided context and the
+// client ID and client secret.
+func (c *Config) TokenSourceWithToken(ctx context.Context, t *oauth2.Token) oauth2.TokenSource {
+	source := &tokenSource{
+		ctx:  ctx,
+		conf: c,
+	}
+	return oauth2.ReuseTokenSource(t, source)
+}
+
 type tokenSource struct {
 	ctx  context.Context
 	conf *Config


### PR DESCRIPTION
We had a problem where we are working against an API that is using Client Credentials, 
That the tokens were killed randomly. So when that happens the OAuth library thought the token was still valid. but we got 401 on everything until the token expired.

So what we needed was somehow to control the "token" and set `t.AccessToken = ""` , 
So I added a new method that is exactly the same as `TokenSource ` but also taking in the token as a pointer and passes that to the `ReuseTokenSource`

Not sure if it's interesting to merge into the upstream repo?
