### PR TITLE
jwt: support PrivateClaims in Config

### DIFF
--- a/jwt/jwt.go
+++ b/jwt/jwt.go
@@ -69,13 +69,10 @@ type Config struct {
 
 	// PrivateClaims optionally specifies custom private claims in the JWT.
 	// See http://tools.ietf.org/html/draft-jones-json-web-token-10#section-4.3
-	//
-	// Private claim values can be different types, therefore interface{} is
-	// used and marshalled using custom code.
 	PrivateClaims map[string]interface{}
 
-	// UseIDToken optionally uses ID token instead of access token when
-	// server returns both 'access_token' and 'id_token'.
+	// UseIDToken optionally specifies whether ID token should be used instead
+	// of access token when the server returns both.
 	UseIDToken bool
 }
 
@@ -176,10 +173,13 @@ func (js jwtSource) Token() (*oauth2.Token, error) {
 		if err != nil {
 			return nil, fmt.Errorf("oauth2: error decoding JWT token: %v", err)
 		}
-		if js.conf.UseIDToken {
-			token.AccessToken = tokenRes.IDToken
-		}
 		token.Expiry = time.Unix(claimSet.Exp, 0)
+	}
+	if js.conf.UseIDToken {
+		if tokenRes.IDToken == "" {
+			return nil, fmt.Errorf("oauth2: response doesn't have JWT token")
+		}
+		token.AccessToken = tokenRes.IDToken
 	}
 	return token, nil
 }

--- a/jwt/jwt.go
+++ b/jwt/jwt.go
@@ -67,7 +67,8 @@ type Config struct {
 	// intended audience.
 	Audience string
 
-	// PrivateClaims optionally specifies private claims in the JWT.
+	// See http://tools.ietf.org/html/draft-jones-json-web-token-10#section-4.3
+	// PrivateClaims optionally specifies custome private claims in the JWT.
 	PrivateClaims map[string]interface{}
 
 	// UseIDToken optionally uses ID token instead of access token.

--- a/jwt/jwt.go
+++ b/jwt/jwt.go
@@ -66,6 +66,9 @@ type Config struct {
 	// request.  If empty, the value of TokenURL is used as the
 	// intended audience.
 	Audience string
+	
+	// PrivateClaims optionally specifies private claims in the JWT.
+	PrivateClaims map[string]interface{}
 }
 
 // TokenSource returns a JWT TokenSource using the configuration
@@ -100,6 +103,7 @@ func (js jwtSource) Token() (*oauth2.Token, error) {
 		Iss:   js.conf.Email,
 		Scope: strings.Join(js.conf.Scopes, " "),
 		Aud:   js.conf.TokenURL,
+		PrivateClaims:  js.conf.PrivateClaims,
 	}
 	if subject := js.conf.Subject; subject != "" {
 		claimSet.Sub = subject

--- a/jwt/jwt.go
+++ b/jwt/jwt.go
@@ -67,11 +67,15 @@ type Config struct {
 	// intended audience.
 	Audience string
 
+	// PrivateClaims optionally specifies custom private claims in the JWT.
 	// See http://tools.ietf.org/html/draft-jones-json-web-token-10#section-4.3
-	// PrivateClaims optionally specifies custome private claims in the JWT.
+	//
+	// Private claim values can be different types, therefore interface{} is
+	// used and marshalled using custom code.
 	PrivateClaims map[string]interface{}
 
-	// UseIDToken optionally uses ID token instead of access token.
+	// UseIDToken optionally uses ID token instead of access token when
+	// server returns both 'access_token' and 'id_token'.
 	UseIDToken bool
 }
 

--- a/jwt/jwt_test.go
+++ b/jwt/jwt_test.go
@@ -11,6 +11,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"reflect"
 	"strings"
 	"testing"
 
@@ -221,6 +222,16 @@ func TestJWTFetch_AssertionPayload(t *testing.T) {
 			TokenURL:     ts.URL,
 			Audience:     "https://example.com",
 		},
+		{
+			Email:        "aaa2@xxx.com",
+			PrivateKey:   dummyPrivateKey,
+			PrivateKeyID: "ABCDEFGHIJKLMNOPQRSTUVWXYZ",
+			TokenURL:     ts.URL,
+			PrivateClaims: map[string]interface{}{
+				"private0": "claim0",
+				"private1": "claim1",
+			},
+		},
 	} {
 		t.Run(conf.Email, func(t *testing.T) {
 			_, err := conf.TokenSource(context.Background()).Token()
@@ -260,6 +271,18 @@ func TestJWTFetch_AssertionPayload(t *testing.T) {
 			}
 			if got, want := claimSet.Prn, conf.Subject; got != want {
 				t.Errorf("payload prn = %q; want %q", got, want)
+			}
+			if len(conf.PrivateClaims) > 0 {
+				var got interface{}
+				if err := json.Unmarshal(gotjson, &got); err != nil {
+					t.Errorf("failed to parse payload; err = %q", err)
+				}
+				m := got.(map[string]interface{})
+				for v, k := range conf.PrivateClaims {
+					if !reflect.DeepEqual(m[v], k) {
+						t.Errorf("payload private claims key = %q: got %q; want %q", v, m[v], k)
+					}
+				}
 			}
 		})
 	}

--- a/jwt/jwt_test.go
+++ b/jwt/jwt_test.go
@@ -280,7 +280,7 @@ func TestJWTFetch_AssertionPayload(t *testing.T) {
 				m := got.(map[string]interface{})
 				for v, k := range conf.PrivateClaims {
 					if !reflect.DeepEqual(m[v], k) {
-						t.Errorf("payload private claims key = %q: got %q; want %q", v, m[v], k)
+						t.Errorf("payload private claims key = %q: got %#v; want %#v", v, m[v], k)
 					}
 				}
 			}


### PR DESCRIPTION
This would help add extra claim for certain 2-leg JWT exchange.

For example, Google service account key can be used to generate an OIDC token, but Google TokenURL requires "target_audience" claims set.

See this example usage:
https://gist.github.com/wlhee/64bc518190053e2122ca1909c2977c67#file-exmaple-go-L29