### PR TITLE
google: update ApprovalForce to use openid connect friendly prompt=consent

### DIFF
--- a/oauth2.go
+++ b/oauth2.go
@@ -117,7 +117,7 @@ var (
 	// ApprovalForce forces the users to view the consent dialog
 	// and confirm the permissions request at the URL returned
 	// from AuthCodeURL, even if they've already done so.
-	ApprovalForce AuthCodeOption = SetAuthURLParam("approval_prompt", "force")
+	ApprovalForce AuthCodeOption = SetAuthURLParam("prompt", "consent")
 )
 
 // An AuthCodeOption is passed to Config.AuthCodeURL.

--- a/oauth2_test.go
+++ b/oauth2_test.go
@@ -43,7 +43,7 @@ func newConf(url string) *Config {
 func TestAuthCodeURL(t *testing.T) {
 	conf := newConf("server")
 	url := conf.AuthCodeURL("foo", AccessTypeOffline, ApprovalForce)
-	const want = "server/auth?access_type=offline&approval_prompt=force&client_id=CLIENT_ID&redirect_uri=REDIRECT_URL&response_type=code&scope=scope1+scope2&state=foo"
+	const want = "server/auth?access_type=offline&prompt=consent&client_id=CLIENT_ID&redirect_uri=REDIRECT_URL&response_type=code&scope=scope1+scope2&state=foo"
 	if got := url; got != want {
 		t.Errorf("got auth code URL = %q; want %q", got, want)
 	}

--- a/oauth2_test.go
+++ b/oauth2_test.go
@@ -43,7 +43,7 @@ func newConf(url string) *Config {
 func TestAuthCodeURL(t *testing.T) {
 	conf := newConf("server")
 	url := conf.AuthCodeURL("foo", AccessTypeOffline, ApprovalForce)
-	const want = "server/auth?access_type=offline&prompt=consent&client_id=CLIENT_ID&redirect_uri=REDIRECT_URL&response_type=code&scope=scope1+scope2&state=foo"
+	const want = "server/auth?access_type=offline&client_id=CLIENT_ID&prompt=consent&redirect_uri=REDIRECT_URL&response_type=code&scope=scope1+scope2&state=foo"
 	if got := url; got != want {
 		t.Errorf("got auth code URL = %q; want %q", got, want)
 	}


### PR DESCRIPTION
It looks like in 2016 or so` approval_prompt=force` was replaced with the open id connect friendly `prompt=consent`. 

See:
- https://openid.net/specs/openid-connect-core-1_0.html#AuthRequest
- https://developers.google.com/identity/sign-in/web/reference#gapiauth2offlineaccessoptions
- https://github.com/googleapis/oauth2client/issues/453
- https://github.com/pomerium/pomerium/pull/82
