### PR TITLE
errors: return all token fetch related errors as structured

### DIFF
--- a/jira/jira.go
+++ b/jira/jira.go
@@ -111,15 +111,15 @@ func (js jwtSource) Token() (*oauth2.Token, error) {
 	hc := oauth2.NewClient(js.ctx, nil)
 	resp, err := hc.PostForm(js.conf.Endpoint.TokenURL, v)
 	if err != nil {
-		return nil, fmt.Errorf("oauth2: cannot fetch token: %v", err)
+		return nil, &oauth2.RetrieveError{Err: err}
 	}
 	defer resp.Body.Close()
 	body, err := ioutil.ReadAll(io.LimitReader(resp.Body, 1<<20))
 	if err != nil {
-		return nil, fmt.Errorf("oauth2: cannot fetch token: %v", err)
+		return nil, &oauth2.RetrieveError{Err: err}
 	}
 	if c := resp.StatusCode; c < 200 || c > 299 {
-		return nil, fmt.Errorf("oauth2: cannot fetch token: %v\nResponse: %s", resp.Status, body)
+		return nil, &oauth2.RetrieveError{Response: resp, Body: body}
 	}
 
 	// tokenRes is the JSON response body.
@@ -129,7 +129,7 @@ func (js jwtSource) Token() (*oauth2.Token, error) {
 		ExpiresIn   int64  `json:"expires_in"` // relative seconds from now
 	}
 	if err := json.Unmarshal(body, &tokenRes); err != nil {
-		return nil, fmt.Errorf("oauth2: cannot fetch token: %v", err)
+		return nil, &oauth2.RetrieveError{Err: err}
 	}
 	token := &oauth2.Token{
 		AccessToken: tokenRes.AccessToken,

--- a/jwt/jwt.go
+++ b/jwt/jwt.go
@@ -124,12 +124,12 @@ func (js jwtSource) Token() (*oauth2.Token, error) {
 	v.Set("assertion", payload)
 	resp, err := hc.PostForm(js.conf.TokenURL, v)
 	if err != nil {
-		return nil, fmt.Errorf("oauth2: cannot fetch token: %v", err)
+		return nil, &oauth2.RetrieveError{Err: err}
 	}
 	defer resp.Body.Close()
 	body, err := ioutil.ReadAll(io.LimitReader(resp.Body, 1<<20))
 	if err != nil {
-		return nil, fmt.Errorf("oauth2: cannot fetch token: %v", err)
+		return nil, &oauth2.RetrieveError{Err: err}
 	}
 	if c := resp.StatusCode; c < 200 || c > 299 {
 		return nil, &oauth2.RetrieveError{
@@ -145,7 +145,7 @@ func (js jwtSource) Token() (*oauth2.Token, error) {
 		ExpiresIn   int64  `json:"expires_in"` // relative seconds from now
 	}
 	if err := json.Unmarshal(body, &tokenRes); err != nil {
-		return nil, fmt.Errorf("oauth2: cannot fetch token: %v", err)
+		return nil, &oauth2.RetrieveError{Err: err}
 	}
 	token := &oauth2.Token{
 		AccessToken: tokenRes.AccessToken,

--- a/token.go
+++ b/token.go
@@ -165,8 +165,11 @@ func retrieveToken(ctx context.Context, c *Config, v url.Values) (*Token, error)
 }
 
 // RetrieveError is the error returned when the token endpoint returns a
-// non-2XX HTTP status code.
+// non-2XX HTTP status code or fails with non-HTTP error
 type RetrieveError struct {
+	// Err is the (net) error happened during HTTP request when response not received
+	Err error
+
 	Response *http.Response
 	// Body is the body that was consumed by reading Response.Body.
 	// It may be truncated.
@@ -174,5 +177,9 @@ type RetrieveError struct {
 }
 
 func (r *RetrieveError) Error() string {
-	return fmt.Sprintf("oauth2: cannot fetch token: %v\nResponse: %s", r.Response.Status, r.Body)
+	if r.Err != nil {
+		return fmt.Sprintf("oauth2: cannot fetch token: %v", r.Err)
+	} else {
+		return fmt.Sprintf("oauth2: cannot fetch token: %v\nResponse: %s", r.Response.Status, r.Body)
+	}
 }


### PR DESCRIPTION
Right now all non-HTTP errors are returned as plain error with combined
text messages into single string, e.g.:
oauth2: cannot fetch token: Post https://oauth2.googleapis.com/token: read tcp 10.0.6.7:46650->172.217.212.95:443: read: connection reset by peer

So caller doesn't have a chance to check easily if underlying error was
retriable (e.g. net.IsTemporary() or DNS error) or not.

This patch wraps ALL errors as RetrieveError with additional Err field
in case it was non-http error.