### PR TITLE
douyu: Add new endpoint of Douyu

### DIFF
--- a/douyu/douyu.go
+++ b/douyu/douyu.go
@@ -1,0 +1,16 @@
+// Copyright 2018 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Package douyu provides constants for using OAuth2 to access Kakao.
+package douyu // import "golang.org/x/oauth2/douyu"
+
+import (
+	"golang.org/x/oauth2"
+)
+
+// Endpoint is Douyu's OAuth 2.0 endpoint.
+var Endpoint = oauth2.Endpoint{
+	AuthURL:  "https://passport.douyu.com/auth/oauth2/authorize",
+	TokenURL: "https://passport.douyu.com/auth/oauth2/access_token",
+}


### PR DESCRIPTION
In the same spirit of package [oauth2/twitch](https://godoc.org/golang.org/x/oauth2/twitch) I would like to add the endpoints for a similar platform that’s considered by many Chinese netizens as an alternative for Twitch in Asia: 斗鱼 — Douyu.