### PR TITLE
More support for Google id-tokens

### DIFF
--- a/google/google.go
+++ b/google/google.go
@@ -226,19 +226,30 @@ func (cs computeSource) Token() (*oauth2.Token, error) {
 		}
 	}
 
-	tokenJSON, err := metadata.Get(tokenURI)
+	metadataResult, err := metadata.Get(tokenURI)
 	if err != nil {
 		return nil, err
 	}
+
 	var res struct {
 		AccessToken  string `json:"access_token"`
 		ExpiresInSec int    `json:"expires_in"`
 		TokenType    string `json:"token_type"`
 	}
-	err = json.NewDecoder(strings.NewReader(tokenJSON)).Decode(&res)
-	if err != nil {
-		return nil, fmt.Errorf("oauth2/google: invalid token JSON from metadata: %v", err)
+
+	if len(cs.idTokenOpts.Audiences) > 0 {
+		// Metadata Server returns raw JWT token as bytes
+		res.AccessToken = metadataResult
+		res.TokenType = "bearer"
+		// approx 5 minute expiration buffer
+		res.ExpiresInSec = 3300
+	} else {
+		err = json.NewDecoder(strings.NewReader(metadataResult)).Decode(&res)
+		if err != nil {
+			return nil, fmt.Errorf("oauth2/google: invalid token JSON from metadata: %v", err)
+		}
 	}
+
 	if res.ExpiresInSec == 0 || res.AccessToken == "" {
 		return nil, fmt.Errorf("oauth2/google: incomplete token received from metadata")
 	}
@@ -247,6 +258,7 @@ func (cs computeSource) Token() (*oauth2.Token, error) {
 		TokenType:   res.TokenType,
 		Expiry:      time.Now().Add(time.Duration(res.ExpiresInSec) * time.Second),
 	}
+
 	// NOTE(cbro): add hidden metadata about where the token is from.
 	// This is needed for detection by client libraries to know that credentials come from the metadata server.
 	// This may be removed in a future version of this library.

--- a/google/google.go
+++ b/google/google.go
@@ -89,6 +89,18 @@ func JWTConfigFromJSON(jsonKey []byte, scope ...string) (*jwt.Config, error) {
 	return f.jwtConfig(scope), nil
 }
 
+// IDConfigFromJSON uses a Google Developers service account JSON key file to request
+// an id-token signed by Google for a specific target audience.
+func IDConfigFromJSON(jsonKey []byte, audience string) (*jwt.Config, error) {
+	cfg, err := JWTConfigFromJSON(jsonKey)
+	if err != nil {
+		return nil, err
+	}
+	cfg.PrivateClaims = map[string]interface{}{"target_audience": audience}
+	cfg.UseIDToken = true
+	return cfg, err
+}
+
 // JSON key file types.
 const (
 	serviceAccountKey  = "service_account"


### PR DESCRIPTION
This adds a Config convenience layer for new JSON key support for google-signed id-tokens (https://github.com/golang/oauth2/commit/950ef44c6e079baf075030377d90bf0c7e4b7b7a)

This also adds a compute instance TokenSource

I didn't find any tests for the current compute instance metadata token source to emulate

cc @wlhee @salrashid123