### PR TITLE
jira: update jira JWT subject per Atlassian's recent GDPR changes

### DIFF
--- a/jira/jira.go
+++ b/jira/jira.go
@@ -81,7 +81,7 @@ func (js jwtSource) Token() (*oauth2.Token, error) {
 	exp := time.Duration(59) * time.Second
 	claimSet := &ClaimSet{
 		Issuer:       fmt.Sprintf("urn:atlassian:connect:clientid:%s", js.conf.ClientID),
-		Subject:      fmt.Sprintf("urn:atlassian:connect:userkey:%s", js.conf.Subject),
+		Subject:      fmt.Sprintf("urn:atlassian:connect:useraccountid:%s", js.conf.Subject),
 		InstalledURL: js.conf.BaseURL,
 		AuthURL:      js.conf.Endpoint.AuthURL,
 		IssuedAt:     time.Now().Unix(),

--- a/jira/jira_test.go
+++ b/jira/jira_test.go
@@ -30,7 +30,7 @@ func TestJWTFetch_JSONResponse(t *testing.T) {
 
 	conf := &Config{
 		BaseURL: "https://my.app.com",
-		Subject: "userkey",
+		Subject: "useraccountId",
 		Config: oauth2.Config{
 			ClientID:     "super_secret_client_id",
 			ClientSecret: "super_shared_secret",
@@ -69,7 +69,7 @@ func TestJWTFetch_BadResponse(t *testing.T) {
 
 	conf := &Config{
 		BaseURL: "https://my.app.com",
-		Subject: "userkey",
+		Subject: "useraccountId",
 		Config: oauth2.Config{
 			ClientID:     "super_secret_client_id",
 			ClientSecret: "super_shared_secret",
@@ -108,7 +108,7 @@ func TestJWTFetch_BadResponseType(t *testing.T) {
 
 	conf := &Config{
 		BaseURL: "https://my.app.com",
-		Subject: "userkey",
+		Subject: "useraccountId",
 		Config: oauth2.Config{
 			ClientID:     "super_secret_client_id",
 			ClientSecret: "super_shared_secret",
@@ -145,7 +145,7 @@ func TestJWTFetch_Assertion(t *testing.T) {
 
 	conf := &Config{
 		BaseURL: "https://my.app.com",
-		Subject: "userkey",
+		Subject: "useraccountId",
 		Config: oauth2.Config{
 			ClientID:     "super_secret_client_id",
 			ClientSecret: "super_shared_secret",


### PR DESCRIPTION
Recently, Atlassian decided to remove `userKey` from JWT construction b/c they determined that it could contain personally identifiable information. They've since switched to the user account ID. This change updates the jira JWT to reflect these recent change.

Fixes golang/oauth2#312