### PR TITLE
Enable JWT for Box.com

### DIFF
--- a/box/box.go
+++ b/box/box.go
@@ -1,0 +1,16 @@
+// Copyright 2019 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Package box provides constants for using OAuth2 to access box.com.
+package box // import "golang.org/x/oauth2/box"
+
+import (
+	"golang.org/x/oauth2"
+)
+
+// Endpoint is box.com's OAuth 2.0 endpoint.
+var Endpoint = oauth2.Endpoint{
+	AuthURL:  "https://account.box.com/api/oauth2/authorize",
+	TokenURL: "https://api.box.com/oauth2/token",
+}


### PR DESCRIPTION
f444c3d box: add box.com OAuth endpoint

More info [here][1].

[1]: https://box-content.readme.io/docs/oauth-20

32e393c Enable passing of additional Querystring params when requesting token

Some JWT Authentication APIs require the ability to pass additional
querystring parameters. For example Box.com API requires "client_id" and
"client_secret" parameters to be set ([ref][1]).

[1]: https://developer.box.com/docs/construct-jwt-claim-manually#section-4-request-access-token

