### PR TITLE
oauth2: validate token in reuseTokenSource

### DIFF
--- a/oauth2.go
+++ b/oauth2.go
@@ -298,7 +298,7 @@ type reuseTokenSource struct {
 func (s *reuseTokenSource) Token() (*Token, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	if s.t.Valid() {
+	if s.t != nil && s.t.Valid() {
 		return s.t, nil
 	}
 	t, err := s.new.Token()


### PR DESCRIPTION
Without this check, for reuseTokenSource types that are created
without a Token (which is permitted), the call to `Token` will
fail since the value of the `reuseTokenSource.t` field
(which holds the token) is nil.