### PR TITLE
oauth2: add an optional interface to add Context support to TokenSource

### DIFF
--- a/transport.go
+++ b/transport.go
@@ -45,7 +45,17 @@ func (t *Transport) RoundTrip(req *http.Request) (*http.Response, error) {
 	if t.Source == nil {
 		return nil, errors.New("oauth2: Transport's Source is nil")
 	}
-	token, err := t.Source.Token()
+
+	var (
+		token *Token
+		err   error
+	)
+	tsctx, ok := t.Source.(tokenSourceContext)
+	if ok {
+		token, err = tsctx.TokenContext(req.Context())
+	} else {
+		token, err = t.Source.Token()
+	}
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
The main motivation for this change is that TokenSource doesn't
support contexts. We would like to access values from an http.Request
context when we are doing the request that generates a new token.

At this stage, this change is just a POC. I'd like to gather reviews
about this approach. If this approach is OK, I'll probably improve docs
and add proper testing.

Fixes golang/go#33131