### PR TITLE
Keep the old refresh_token when not present

### DIFF
--- a/oauth2.go
+++ b/oauth2.go
@@ -275,7 +275,7 @@ func (tf *tokenRefresher) Token() (*Token, error) {
 	if err != nil {
 		return nil, err
 	}
-	if tf.refreshToken != tk.RefreshToken {
+	if tf.refreshToken != tk.RefreshToken && tk.RefreshToken != "" {
 		tf.refreshToken = tk.RefreshToken
 	}
 	return tk, err


### PR DESCRIPTION
In case the new token (from refresh request) doesn't respond with a new refreshToken, keep the old refresh token.