### PR TITLE
Remove transport deprecated method CancelRequest

### DIFF
--- a/transport.go
+++ b/transport.go
@@ -6,9 +6,7 @@ package oauth2
 
 import (
 	"errors"
-	"io"
 	"net/http"
-	"sync"
 )
 
 // Transport is an http.RoundTripper that makes OAuth 2.0 HTTP requests,
@@ -25,9 +23,6 @@ type Transport struct {
 	// Base is the base RoundTripper used to make HTTP requests.
 	// If nil, http.DefaultTransport is used.
 	Base http.RoundTripper
-
-	mu     sync.Mutex                      // guards modReq
-	modReq map[*http.Request]*http.Request // original -> modified
 }
 
 // RoundTrip authorizes and authenticates the request with an
@@ -50,37 +45,12 @@ func (t *Transport) RoundTrip(req *http.Request) (*http.Response, error) {
 		return nil, err
 	}
 
-	req2 := cloneRequest(req) // per RoundTripper contract
-	token.SetAuthHeader(req2)
-	t.setModReq(req, req2)
-	res, err := t.base().RoundTrip(req2)
+	token.SetAuthHeader(req)
+	res, err := t.base().RoundTrip(req)
 
 	// req.Body is assumed to have been closed by the base RoundTripper.
 	reqBodyClosed = true
-
-	if err != nil {
-		t.setModReq(req, nil)
-		return nil, err
-	}
-	res.Body = &onEOFReader{
-		rc: res.Body,
-		fn: func() { t.setModReq(req, nil) },
-	}
-	return res, nil
-}
-
-// CancelRequest cancels an in-flight request by closing its connection.
-func (t *Transport) CancelRequest(req *http.Request) {
-	type canceler interface {
-		CancelRequest(*http.Request)
-	}
-	if cr, ok := t.base().(canceler); ok {
-		t.mu.Lock()
-		modReq := t.modReq[req]
-		delete(t.modReq, req)
-		t.mu.Unlock()
-		cr.CancelRequest(modReq)
-	}
+	return res, err
 }
 
 func (t *Transport) base() http.RoundTripper {
@@ -88,57 +58,4 @@ func (t *Transport) base() http.RoundTripper {
 		return t.Base
 	}
 	return http.DefaultTransport
-}
-
-func (t *Transport) setModReq(orig, mod *http.Request) {
-	t.mu.Lock()
-	defer t.mu.Unlock()
-	if t.modReq == nil {
-		t.modReq = make(map[*http.Request]*http.Request)
-	}
-	if mod == nil {
-		delete(t.modReq, orig)
-	} else {
-		t.modReq[orig] = mod
-	}
-}
-
-// cloneRequest returns a clone of the provided *http.Request.
-// The clone is a shallow copy of the struct and its Header map.
-func cloneRequest(r *http.Request) *http.Request {
-	// shallow copy of the struct
-	r2 := new(http.Request)
-	*r2 = *r
-	// deep copy of the Header
-	r2.Header = make(http.Header, len(r.Header))
-	for k, s := range r.Header {
-		r2.Header[k] = append([]string(nil), s...)
-	}
-	return r2
-}
-
-type onEOFReader struct {
-	rc io.ReadCloser
-	fn func()
-}
-
-func (r *onEOFReader) Read(p []byte) (n int, err error) {
-	n, err = r.rc.Read(p)
-	if err == io.EOF {
-		r.runFunc()
-	}
-	return
-}
-
-func (r *onEOFReader) Close() error {
-	err := r.rc.Close()
-	r.runFunc()
-	return err
-}
-
-func (r *onEOFReader) runFunc() {
-	if fn := r.fn; fn != nil {
-		fn()
-		r.fn = nil
-	}
 }


### PR DESCRIPTION
As mentioned in issue #271 the CancelRequest method is deprecated and was replaced with context cancellation in Go 1.7. This should do away with the need to store a map of modified requests.

My main motivation for this code cleanup is to allow returning a writable body response in the transport https://golang.org/src/net/http/response.go#L344 needed in websockets and other protocols protected by oauth2.