### PR TITLE
clientcredentials: add example

### DIFF
--- a/clientcredentials/example_test.go
+++ b/clientcredentials/example_test.go
@@ -1,0 +1,28 @@
+// Copyright 2014 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package oauth2_test
+
+import (
+	"context"
+
+	"golang.org/x/oauth2"
+)
+
+func ExampleConfig() {
+	ctx := context.Background()
+	conf := &oauth2.Config{
+		ClientID:     "YOUR_CLIENT_ID",
+		ClientSecret: "YOUR_CLIENT_SECRET",
+		Scopes:       []string{"SCOPE1", "SCOPE2"},
+		Endpoint: oauth2.Endpoint{
+			TokenURL: "https://provider.com/o/oauth2/token",
+		},
+	}
+
+	// For the clientcredentials flow simply get a client from
+	// the Config directly.
+	client := conf.Client(ctx, tok)
+	client.Get("...")
+}

--- a/clientcredentials/example_test.go
+++ b/clientcredentials/example_test.go
@@ -2,27 +2,25 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-package oauth2_test
+package clientcredentials_test
 
 import (
 	"context"
 
-	"golang.org/x/oauth2"
+	"golang.org/x/oauth2/clientcredentials"
 )
 
 func ExampleConfig() {
 	ctx := context.Background()
-	conf := &oauth2.Config{
+	conf := &clientcredentials.Config{
 		ClientID:     "YOUR_CLIENT_ID",
 		ClientSecret: "YOUR_CLIENT_SECRET",
 		Scopes:       []string{"SCOPE1", "SCOPE2"},
-		Endpoint: oauth2.Endpoint{
-			TokenURL: "https://provider.com/o/oauth2/token",
-		},
+		TokenURL:     "https://provider.com/o/oauth2/token",
 	}
 
 	// For the clientcredentials flow simply get a client from
 	// the Config directly.
-	client := conf.Client(ctx, tok)
+	client := conf.Client(ctx)
 	client.Get("...")
 }


### PR DESCRIPTION
Add a simple example for the clientcredentials workflow.

Related to:
https://github.com/golang/oauth2/issues/305
https://github.com/golang/oauth2/issues/107

and there is a dearth of examples overall.
