### PR TITLE
Update Facebook endpoint URLs to v6.0

### DIFF
--- a/facebook/facebook.go
+++ b/facebook/facebook.go
@@ -11,6 +11,6 @@ import (
 
 // Endpoint is Facebook's OAuth 2.0 endpoint.
 var Endpoint = oauth2.Endpoint{
-	AuthURL:  "https://www.facebook.com/v3.2/dialog/oauth",
-	TokenURL: "https://graph.facebook.com/v3.2/oauth/access_token",
+	AuthURL:  "https://www.facebook.com/v6.0/dialog/oauth",
+	TokenURL: "https://graph.facebook.com/v6.0/oauth/access_token",
 }


### PR DESCRIPTION
Per the URLs currently documented at [Manually Build a Login Flow](https://developers.facebook.com/docs/facebook-login/manually-build-a-login-flow/#logindialog).