### PR TITLE
Create slackv2.go for new slack Oauth endpoints

### DIFF
--- a/slack/slackv2.go
+++ b/slack/slackv2.go
@@ -3,15 +3,15 @@
 // license that can be found in the LICENSE file.
 
 // Package slack provides constants for using OAuth2 to access Slack.
-// For Classic Slack Apps - https://api.slack.com/docs/oauth
-package slack // import "golang.org/x/oauth2/slack"
+// For Granular Scoped Apps - https://api.slack.com/authentication/oauth-v2
+package slackv2 // import "golang.org/x/oauth2/slackv2"
 
 import (
 	"golang.org/x/oauth2"
 )
 
-// Endpoint is Slack's classic OAuth 2.0 endpoint.
+// Endpoint is Slack's new OAuth 2.0 endpoint.
 var Endpoint = oauth2.Endpoint{
-	AuthURL:  "https://slack.com/oauth/authorize",
-	TokenURL: "https://slack.com/api/oauth.access",
+	AuthURL:  "https://slack.com/oauth/v2/authorize",
+	TokenURL: "https://slack.com/api/oauth.v2.access",
 }

--- a/slackv2/slackv2.go
+++ b/slackv2/slackv2.go
@@ -4,7 +4,7 @@
 
 // Package slack provides constants for using OAuth2 to access Slack.
 // For Granular Scoped Apps - https://api.slack.com/authentication/oauth-v2
-package slackv2 // import "golang.org/x/oauth2/slackv2"
+package slack // import "golang.org/x/oauth2/slackv2"
 
 import (
 	"golang.org/x/oauth2"


### PR DESCRIPTION
Slack has introduced granular scoped apps which uses a new OAuth endpoint. When you make a new slack app, this is the new default.

The previous slack endpoint still works for classic slack apps. So I figured it might make sense to offer both still. These classic slack apps can still be made and a majority of existing slack apps use them. 

If y'all think it would be better just update `slack.go` instead of creating a new `slackv2.go`, let me know. I'm a go noob, so any advice would be appreciated. 

Issue: https://github.com/golang/oauth2/issues/412

