### PR TITLE
oauth2: remove unnecessary word

### DIFF
--- a/oauth2.go
+++ b/oauth2.go
@@ -140,7 +140,7 @@ func SetAuthURLParam(key, value string) AuthCodeOption {
 //
 // State is a token to protect the user from CSRF attacks. You must
 // always provide a non-empty string and validate that it matches the
-// the state query parameter on your redirect callback.
+// state query parameter on your redirect callback.
 // See http://tools.ietf.org/html/rfc6749#section-10.12 for more info.
 //
 // Opts may include AccessTypeOnline or AccessTypeOffline, as well


### PR DESCRIPTION
- It seemed like 'the' was written in double, so I corrected it.