### PR TITLE
Added Withings Health Mate OAuth2 endpoint

### DIFF
--- a/withings/withings.go
+++ b/withings/withings.go
@@ -1,0 +1,16 @@
+// Copyright 2018 The oauth2 Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Package withings provides constants for using OAuth2 to access the Withings Health Mate API, formerly known as the Nokia Health Mate API.
+package withings
+
+import (
+	"golang.org/x/oauth2"
+)
+
+// Endpoint is the Withings Health Mate OAuth 2.0 endpoint.
+var Endpoint = oauth2.Endpoint{
+	AuthURL:  "https://account.withings.com/oauth2_user/authorize2",
+	TokenURL: "https://account.withings.com/oauth2/token",
+}


### PR DESCRIPTION
Nokia acquired Withings and so Withings became Nokia Health.  Nokia Health has parted ways with Nokia, and is now Withings again.  This caused their API endpoints to change from the account.health.nokia.com domain to the account.withings.com domain.

I do not know if we should then remove the `nokiahealth/nokiahealth.go` file.  I suspect yes, but I would like feedback before doing so.