### PR TITLE
Added Sign in with Apple endpoints.

### DIFF
--- a/endpoints/endpoints.go
+++ b/endpoints/endpoints.go
@@ -17,6 +17,12 @@ var Amazon = oauth2.Endpoint{
 	TokenURL: "https://api.amazon.com/auth/o2/token",
 }
 
+// Apple is the endpoint for Sign in with Apple.
+var AppleSignIn = oauth2.Endpoint{
+	AuthURL:  "https://appleid.apple.com/auth/authorize",
+	TokenURL: "https://appleid.apple.com/auth/token",
+}
+
 // Bitbucket is the endpoint for Bitbucket.
 var Bitbucket = oauth2.Endpoint{
 	AuthURL:  "https://bitbucket.org/site/oauth2/authorize",


### PR DESCRIPTION
Apple’s new “Sign-in with Apple” service is based on OAuth 2.0 and OIDC (OpenID Connect) plus JWT for the application credentials. The public keys to verify the JSON Web Token (JWT) signature are available [here](https://developer.apple.com/documentation/sign_in_with_apple/fetch_apple_s_public_key_for_verifying_token_signature). We can validate the authorization grant code with Apple to obtain tokens or validate an existing refresh token using [this endpoint](https://developer.apple.com/documentation/sign_in_with_apple/generate_and_validate_tokens). And the documentation for the [token response is available here](https://developer.apple.com/documentation/sign_in_with_apple/tokenresponse).

Meet the requirements of the review comments for #386.