### PR TITLE
Added Splitwise endpoints

### DIFF
--- a/endpoints/endpoints.go
+++ b/endpoints/endpoints.go
@@ -155,6 +155,12 @@ var Slack = oauth2.Endpoint{
 	TokenURL: "https://slack.com/api/oauth.access",
 }
 
+// Splitwise is the endpoint for Splitwise.
+var Splitwise = oauth2.Endpoint{
+	AuthURL:  "https://www.splitwise.com/oauth/authorize",
+	TokenURL: "https://www.splitwise.com/oauth/token",
+}
+
 // Spotify is the endpoint for Spotify.
 var Spotify = oauth2.Endpoint{
 	AuthURL:  "https://accounts.spotify.com/authorize",


### PR DESCRIPTION
[Splitwise](https://splitwise.com) allows developers to access their APIs via OAuth2. The documentation can be found here http://dev.splitwise.com/#authentication