### PR TITLE
oauth2: add new RawBody field to oauth2.Token

### DIFF
--- a/internal/token.go
+++ b/internal/token.go
@@ -54,6 +54,9 @@ type Token struct {
 	// Raw optionally contains extra metadata from the server
 	// when updating a token.
 	Raw interface{}
+
+	// RawBody is the response body from the oauth2 access token request/response flow
+	RawBody []byte
 }
 
 // tokenJSON is the struct representing the HTTP response from OAuth2
@@ -278,6 +281,7 @@ func doTokenRoundTrip(ctx context.Context, req *http.Request) (*Token, error) {
 		}
 		json.Unmarshal(body, &token.Raw) // no error checks for optional fields
 	}
+	token.RawBody = body
 	if token.AccessToken == "" {
 		return nil, errors.New("oauth2: server response missing access_token")
 	}

--- a/token.go
+++ b/token.go
@@ -49,6 +49,10 @@ type Token struct {
 	// mechanisms for that TokenSource will not be used.
 	Expiry time.Time `json:"expiry,omitempty"`
 
+	// RawBody provides access to the raw body response from
+	// the oauth2 authorize flow
+	RawBody []byte `json:"-"`
+
 	// raw optionally contains extra metadata from the server
 	// when updating a token.
 	raw interface{}
@@ -146,6 +150,7 @@ func tokenFromInternal(t *internal.Token) *Token {
 		TokenType:    t.TokenType,
 		RefreshToken: t.RefreshToken,
 		Expiry:       t.Expiry,
+		RawBody:      t.RawBody,
 		raw:          t.Raw,
 	}
 }


### PR DESCRIPTION
This adds the ability to retrieve the raw HTTP response body from the token authorization flows. This is handy for services such as Slack as they include additional data in the response

For example, taking the Slack v2 oauth.access request https://api.slack.com/methods/oauth.v2.access

Gives you the following response 

```json
{
    "ok": true,
    "access_token": "xoxb-17653672481-19874698323-pdFZKVeTuE8sk7oOcBrzbqgy",
    "token_type": "bot",
    "scope": "commands,incoming-webhook",
    "bot_user_id": "U0KRQLJ9H",
    "app_id": "A0KRD7HC3",
    "team": {
        "name": "Slack Softball Team",
        "id": "T9TK3CUKW"
    },
    "enterprise": {
        "name": "slack-sports",
        "id": "E12345678"
    },
    "authed_user": {
        "id": "U1234",
        "scope": "chat:write",
        "access_token": "xoxp-1234",
        "token_type": "user"
    }
}
```

To gain access to this information a user of the `golang/oauth2` library has to use the `oauth2.Token.Extra()` func. This is okay for a few fields and fields that are in the root JSON object but once you start dealing with nested fields this can become cumbersome

```go
if botuserid, ok := token.Extra("bot_user_id").(string); ok {
    // use botuserid
}

if team, ok := token.Extra("team").(map[string]interface{}); ok {
	if teamid, ok := team["id"].(string); ok {
		// use teamid
	}
	if teamname, ok := team["name"].(string); ok {
		// use teamname
	}
}
```

This PR adds the ability for accessing the response body from the Token request and allows a consumer to decode it into a struct to simplify the retrieval of extra fields