### PR TITLE
google: support url-sourced 3rd party credentials

### DIFF
--- a/google/google.go
+++ b/google/google.go
@@ -115,14 +115,13 @@ type credentialsFile struct {
 	RefreshToken string `json:"refresh_token"`
 
 	// External Account fields
-	Audience string `json:"audience"`
-	SubjectTokenType string `json:"subject_token_type"`
-	TokenURLExternal string `json:"token_url"`
-	TokenInfoURL string `json:"token_info_url"`
-	ServiceAccountImpersonationURL string `json:"service_account_impersonation_url"`
-	CredentialSource externalaccount.CredentialSource `json:"credential_source"`
-	QuotaProjectID string `json:"quota_project_id"`
-
+	Audience                       string                           `json:"audience"`
+	SubjectTokenType               string                           `json:"subject_token_type"`
+	TokenURLExternal               string                           `json:"token_url"`
+	TokenInfoURL                   string                           `json:"token_info_url"`
+	ServiceAccountImpersonationURL string                           `json:"service_account_impersonation_url"`
+	CredentialSource               externalaccount.CredentialSource `json:"credential_source"`
+	QuotaProjectID                 string                           `json:"quota_project_id"`
 }
 
 func (f *credentialsFile) jwtConfig(scopes []string) *jwt.Config {
@@ -155,16 +154,16 @@ func (f *credentialsFile) tokenSource(ctx context.Context, scopes []string) (oau
 		return cfg.TokenSource(ctx, tok), nil
 	case externalAccountKey:
 		cfg := &externalaccount.Config{
-			Audience:	f.Audience,
-			SubjectTokenType: f.SubjectTokenType,
-			TokenURL: f.TokenURLExternal,
-			TokenInfoURL: f.TokenInfoURL,
+			Audience:                       f.Audience,
+			SubjectTokenType:               f.SubjectTokenType,
+			TokenURL:                       f.TokenURLExternal,
+			TokenInfoURL:                   f.TokenInfoURL,
 			ServiceAccountImpersonationURL: f.ServiceAccountImpersonationURL,
-			ClientSecret: f.ClientSecret,
-			ClientID: f.ClientID,
-			CredentialSource: f.CredentialSource,
-			QuotaProjectID: f.QuotaProjectID,
-			Scopes: scopes,
+			ClientSecret:                   f.ClientSecret,
+			ClientID:                       f.ClientID,
+			CredentialSource:               f.CredentialSource,
+			QuotaProjectID:                 f.QuotaProjectID,
+			Scopes:                         scopes,
 		}
 		return cfg.TokenSource(ctx), nil
 	case "":

--- a/google/internal/externalaccount/basecredentials.go
+++ b/google/internal/externalaccount/basecredentials.go
@@ -66,11 +66,11 @@ type CredentialSource struct {
 }
 
 // parse determines the type of CredentialSource needed
-func (c *Config) parse() baseCredentialSource {
+func (c *Config) parse(ctx context.Context) baseCredentialSource {
 	if c.CredentialSource.File != "" {
 		return fileCredentialSource{File: c.CredentialSource.File, Format: c.CredentialSource.Format}
 	} else if c.CredentialSource.URL != "" {
-		return urlCredentialSource{URL: c.CredentialSource.URL, Format: c.CredentialSource.Format}
+		return urlCredentialSource{URL: c.CredentialSource.URL, Format: c.CredentialSource.Format, ctx: ctx}
 	}
 	return nil
 }
@@ -89,7 +89,7 @@ type tokenSource struct {
 func (ts tokenSource) Token() (*oauth2.Token, error) {
 	conf := ts.conf
 
-	credSource := conf.parse()
+	credSource := conf.parse(ts.ctx)
 	if credSource == nil {
 		return nil, fmt.Errorf("oauth2/google: unable to parse credential source")
 	}

--- a/google/internal/externalaccount/basecredentials.go
+++ b/google/internal/externalaccount/basecredentials.go
@@ -69,6 +69,8 @@ type CredentialSource struct {
 func (c *Config) parse() baseCredentialSource {
 	if c.CredentialSource.File != "" {
 		return fileCredentialSource{File: c.CredentialSource.File, Format: c.CredentialSource.Format}
+	} else if c.CredentialSource.URL != "" {
+		return urlCredentialSource{URL: c.CredentialSource.URL, Format: c.CredentialSource.Format}
 	}
 	return nil
 }

--- a/google/internal/externalaccount/filecredsource_test.go
+++ b/google/internal/externalaccount/filecredsource_test.go
@@ -5,6 +5,7 @@
 package externalaccount
 
 import (
+	"context"
 	"testing"
 )
 
@@ -55,7 +56,7 @@ func TestRetrieveFileSubjectToken(t *testing.T) {
 		tfc.CredentialSource = test.cs
 
 		t.Run(test.name, func(t *testing.T) {
-			out, err := tfc.parse().subjectToken()
+			out, err := tfc.parse(context.Background()).subjectToken()
 			if err != nil {
 				t.Errorf("Method subjectToken() errored.")
 			} else if test.want != out {

--- a/google/internal/externalaccount/urlcredsource.go
+++ b/google/internal/externalaccount/urlcredsource.go
@@ -5,39 +5,39 @@
 package externalaccount
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
+	"golang.org/x/oauth2"
 	"io"
 	"io/ioutil"
 	"net/http"
-	"strings"
 )
 
 type urlCredentialSource struct {
 	URL     string
 	Headers map[string]string
 	Format  format
+	ctx     context.Context
 }
 
 func (cs urlCredentialSource) subjectToken() (string, error) {
-	client := http.Client{}
-	req, err := http.NewRequest("GET", cs.URL, strings.NewReader(""))
+	client := oauth2.NewClient(cs.ctx, nil)
+	req, err := http.NewRequest("GET", cs.URL, nil)
 
 	for key, val := range cs.Headers {
 		req.Header.Add(key, val)
 	}
 	resp, err := client.Do(req)
 	if err != nil {
-		fmt.Errorf("oauth2/google: invalid response when retrieving subject token: %v", err)
-		return "", err
+		return "", fmt.Errorf("oauth2/google: invalid response when retrieving subject token: %v", err)
 	}
 	defer resp.Body.Close()
 
 	tokenBytes, err := ioutil.ReadAll(io.LimitReader(resp.Body, 1<<20))
 	if err != nil {
-		fmt.Errorf("oauth2/google: invalid body in subject token URL query: %v", err)
-		return "", err
+		return "", fmt.Errorf("oauth2/google: invalid body in subject token URL query: %v", err)
 	}
 
 	switch cs.Format.Type {

--- a/google/internal/externalaccount/urlcredsource.go
+++ b/google/internal/externalaccount/urlcredsource.go
@@ -15,9 +15,9 @@ import (
 )
 
 type urlCredentialSource struct {
-	URL string
+	URL     string
 	Headers map[string]string
-	Format format
+	Format  format
 }
 
 func (cs urlCredentialSource) subjectToken() (string, error) {

--- a/google/internal/externalaccount/urlcredsource.go
+++ b/google/internal/externalaccount/urlcredsource.go
@@ -25,6 +25,10 @@ type urlCredentialSource struct {
 func (cs urlCredentialSource) subjectToken() (string, error) {
 	client := oauth2.NewClient(cs.ctx, nil)
 	req, err := http.NewRequest("GET", cs.URL, nil)
+	if err != nil {
+		return "", fmt.Errorf("oauth2/google: HTTP request for URL-sourced credential failed: %v", err)
+	}
+	req = req.WithContext(cs.ctx)
 
 	for key, val := range cs.Headers {
 		req.Header.Add(key, val)

--- a/google/internal/externalaccount/urlcredsource.go
+++ b/google/internal/externalaccount/urlcredsource.go
@@ -1,0 +1,67 @@
+// Copyright 2020 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package externalaccount
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"strings"
+)
+
+type urlCredentialSource struct {
+	URL string
+	Headers map[string]string
+	Format format
+}
+
+func (cs urlCredentialSource) subjectToken() (string, error) {
+	client := http.Client{}
+	req, err := http.NewRequest("GET", cs.URL, strings.NewReader(""))
+
+	for key, val := range cs.Headers {
+		req.Header.Add(key, val)
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		fmt.Errorf("oauth2/google: invalid response when retrieving subject token: %v", err)
+		return "", err
+	}
+	defer resp.Body.Close()
+
+	tokenBytes, err := ioutil.ReadAll(io.LimitReader(resp.Body, 1<<20))
+	if err != nil {
+		fmt.Errorf("oauth2/google: invalid body in subject token URL query: %v", err)
+		return "", err
+	}
+
+	switch cs.Format.Type {
+	case "json":
+		jsonData := make(map[string]interface{})
+		err = json.Unmarshal(tokenBytes, &jsonData)
+		if err != nil {
+			return "", fmt.Errorf("oauth2/google: failed to unmarshal subject token file: %v", err)
+		}
+		val, ok := jsonData[cs.Format.SubjectTokenFieldName]
+		if !ok {
+			return "", errors.New("oauth2/google: provided subject_token_field_name not found in credentials")
+		}
+		token, ok := val.(string)
+		if !ok {
+			return "", errors.New("oauth2/google: improperly formatted subject token")
+		}
+		return token, nil
+	case "text":
+		return string(tokenBytes), nil
+	case "":
+		return string(tokenBytes), nil
+	default:
+		return "", errors.New("oauth2/google: invalid credential_source file format type")
+	}
+
+}

--- a/google/internal/externalaccount/urlcredsource_test.go
+++ b/google/internal/externalaccount/urlcredsource_test.go
@@ -13,8 +13,6 @@ import (
 
 var myURLToken = "testTokenValue"
 
-
-
 func TestRetrieveURLSubjectToken_Text(t *testing.T) {
 
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -24,7 +22,7 @@ func TestRetrieveURLSubjectToken_Text(t *testing.T) {
 		w.Write([]byte("testTokenValue"))
 	}))
 	cs := CredentialSource{
-		URL: ts.URL,
+		URL:    ts.URL,
 		Format: format{Type: fileTypeText},
 	}
 	tfc := testFileConfig
@@ -81,14 +79,13 @@ func TestRetrieveURLSubjectToken_JSON(t *testing.T) {
 		w.Write(jsonResp)
 	}))
 	cs := CredentialSource{
-		URL: ts.URL,
+		URL:    ts.URL,
 		Format: format{Type: fileTypeJSON, SubjectTokenFieldName: "SubjToken"},
 	}
 	tfc := testFileConfig
 	tfc.CredentialSource = cs
 
 	out, err := tfc.parse().subjectToken()
-
 
 	if err != nil {
 		t.Fatalf("%v", err)

--- a/google/internal/externalaccount/urlcredsource_test.go
+++ b/google/internal/externalaccount/urlcredsource_test.go
@@ -1,0 +1,100 @@
+// Copyright 2020 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package externalaccount
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+var myURLToken = "testTokenValue"
+
+
+
+func TestRetrieveURLSubjectToken_Text(t *testing.T) {
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != "GET" {
+			t.Errorf("Unexpected request method, %v is found", r.Method)
+		}
+		w.Write([]byte("testTokenValue"))
+	}))
+	cs := CredentialSource{
+		URL: ts.URL,
+		Format: format{Type: fileTypeText},
+	}
+	tfc := testFileConfig
+	tfc.CredentialSource = cs
+
+	out, err := tfc.parse().subjectToken()
+	if err != nil {
+		t.Fatalf("retrieveSubjectToken() failed: %v", err)
+	}
+	if out != myURLToken {
+		t.Errorf("got %v but want %v", out, myURLToken)
+	}
+
+}
+
+// Checking that retrieveSubjectToken properly defaults to type text
+func TestRetrieveURLSubjectToken_Untyped(t *testing.T) {
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != "GET" {
+			t.Errorf("Unexpected request method, %v is found", r.Method)
+		}
+		w.Write([]byte("testTokenValue"))
+	}))
+	cs := CredentialSource{
+		URL: ts.URL,
+	}
+	tfc := testFileConfig
+	tfc.CredentialSource = cs
+
+	out, err := tfc.parse().subjectToken()
+	if err != nil {
+		t.Fatalf("Failed to retrieve USRL subject token: %v", err)
+	}
+	if out != myURLToken {
+		t.Errorf("got %v but want %v", out, myURLToken)
+	}
+
+}
+
+func TestRetrieveURLSubjectToken_JSON(t *testing.T) {
+	type tokenResponse struct {
+		TestToken string `json:"SubjToken"`
+	}
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got, want := r.Method, "GET"; got != want {
+			t.Errorf("got %v, but want %v", r.Method, want)
+		}
+		resp := tokenResponse{TestToken: "testTokenValue"}
+		jsonResp, err := json.Marshal(resp)
+		if err != nil {
+			t.Errorf("Failed to marshal values: %v", err)
+		}
+		w.Write(jsonResp)
+	}))
+	cs := CredentialSource{
+		URL: ts.URL,
+		Format: format{Type: fileTypeJSON, SubjectTokenFieldName: "SubjToken"},
+	}
+	tfc := testFileConfig
+	tfc.CredentialSource = cs
+
+	out, err := tfc.parse().subjectToken()
+
+
+	if err != nil {
+		t.Fatalf("%v", err)
+	}
+	if out != myURLToken {
+		t.Errorf("got %v but want %v", out, myURLToken)
+	}
+
+}

--- a/google/internal/externalaccount/urlcredsource_test.go
+++ b/google/internal/externalaccount/urlcredsource_test.go
@@ -14,7 +14,6 @@ import (
 var myURLToken = "testTokenValue"
 
 func TestRetrieveURLSubjectToken_Text(t *testing.T) {
-
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != "GET" {
 			t.Errorf("Unexpected request method, %v is found", r.Method)
@@ -35,12 +34,10 @@ func TestRetrieveURLSubjectToken_Text(t *testing.T) {
 	if out != myURLToken {
 		t.Errorf("got %v but want %v", out, myURLToken)
 	}
-
 }
 
 // Checking that retrieveSubjectToken properly defaults to type text
 func TestRetrieveURLSubjectToken_Untyped(t *testing.T) {
-
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != "GET" {
 			t.Errorf("Unexpected request method, %v is found", r.Method)
@@ -55,12 +52,11 @@ func TestRetrieveURLSubjectToken_Untyped(t *testing.T) {
 
 	out, err := tfc.parse().subjectToken()
 	if err != nil {
-		t.Fatalf("Failed to retrieve USRL subject token: %v", err)
+		t.Fatalf("Failed to retrieve URL subject token: %v", err)
 	}
 	if out != myURLToken {
 		t.Errorf("got %v but want %v", out, myURLToken)
 	}
-
 }
 
 func TestRetrieveURLSubjectToken_JSON(t *testing.T) {
@@ -86,12 +82,10 @@ func TestRetrieveURLSubjectToken_JSON(t *testing.T) {
 	tfc.CredentialSource = cs
 
 	out, err := tfc.parse().subjectToken()
-
 	if err != nil {
 		t.Fatalf("%v", err)
 	}
 	if out != myURLToken {
 		t.Errorf("got %v but want %v", out, myURLToken)
 	}
-
 }

--- a/google/internal/externalaccount/urlcredsource_test.go
+++ b/google/internal/externalaccount/urlcredsource_test.go
@@ -5,6 +5,7 @@
 package externalaccount
 
 import (
+	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -27,7 +28,7 @@ func TestRetrieveURLSubjectToken_Text(t *testing.T) {
 	tfc := testFileConfig
 	tfc.CredentialSource = cs
 
-	out, err := tfc.parse().subjectToken()
+	out, err := tfc.parse(context.Background()).subjectToken()
 	if err != nil {
 		t.Fatalf("retrieveSubjectToken() failed: %v", err)
 	}
@@ -50,7 +51,7 @@ func TestRetrieveURLSubjectToken_Untyped(t *testing.T) {
 	tfc := testFileConfig
 	tfc.CredentialSource = cs
 
-	out, err := tfc.parse().subjectToken()
+	out, err := tfc.parse(context.Background()).subjectToken()
 	if err != nil {
 		t.Fatalf("Failed to retrieve URL subject token: %v", err)
 	}
@@ -81,7 +82,7 @@ func TestRetrieveURLSubjectToken_JSON(t *testing.T) {
 	tfc := testFileConfig
 	tfc.CredentialSource = cs
 
-	out, err := tfc.parse().subjectToken()
+	out, err := tfc.parse(context.Background()).subjectToken()
 	if err != nil {
 		t.Fatalf("%v", err)
 	}


### PR DESCRIPTION
Implements functionality to allow for URL-sourced 3rd party credentials, expanding the functionality added in #462 .  