### PR TITLE
Add ability to use non-escaped header auth style

### DIFF
--- a/internal/token.go
+++ b/internal/token.go
@@ -106,9 +106,10 @@ func RegisterBrokenAuthHeaderProvider(tokenURL string) {}
 type AuthStyle int
 
 const (
-	AuthStyleUnknown  AuthStyle = 0
-	AuthStyleInParams AuthStyle = 1
-	AuthStyleInHeader AuthStyle = 2
+	AuthStyleUnknown          AuthStyle = 0
+	AuthStyleInParams         AuthStyle = 1
+	AuthStyleInHeader         AuthStyle = 2
+	AuthStyleInHeaderNoEscape AuthStyle = 3
 )
 
 // authStyleCache is the set of tokenURLs we've successfully used via
@@ -173,6 +174,8 @@ func newTokenRequest(tokenURL, clientID, clientSecret string, v url.Values, auth
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 	if authStyle == AuthStyleInHeader {
 		req.SetBasicAuth(url.QueryEscape(clientID), url.QueryEscape(clientSecret))
+	} else if authStyle == AuthStyleInHeaderNoEscape {
+		req.SetBasicAuth(clientID, clientSecret)
 	}
 	return req, nil
 }

--- a/oauth2.go
+++ b/oauth2.go
@@ -97,6 +97,11 @@ const (
 	// using HTTP Basic Authorization. This is an optional style
 	// described in the OAuth2 RFC 6749 section 2.3.1.
 	AuthStyleInHeader AuthStyle = 2
+
+	// AuthStyleInHeaderNoEscape operates just like AuthStyleInHeader
+	// with the exception that the client_id and client_password are
+	// not URL escaped to accommodate services that do not suport this.
+	AuthStyleInHeaderNoEscape AuthStyle = 3
 )
 
 var (


### PR DESCRIPTION
Some OAuth providers do not adhere to the standard of accepting query escaped credentials when using Basic header auth. If your client ID or client secret contains non-standard URL query characters they will be rejected by the OAuth provider.
The current implementation always query escapes the `client_id` and `client_secret`:
`req.SetBasicAuth(url.QueryEscape(clientID), url.QueryEscape(clientSecret))`
This PR proposes a new AuthStyle `AuthStyleInHeaderNoEscape` that will pass the credentials unescaped. 
This has been raised several times:
https://github.com/golang/oauth2/issues/251
https://github.com/golang/oauth2/issues/318
https://github.com/golang/oauth2/issues/320
but without this feature this library cannot be used against some key OAuth providers.

This PR replaces https://github.com/golang/oauth2/pull/351 which was raised in an early version of the code.

