### PR TITLE
google: unexport private structs and funcs

### DIFF
--- a/google/internal/externalaccount/basecredentials.go
+++ b/google/internal/externalaccount/basecredentials.go
@@ -124,7 +124,7 @@ func (ts tokenSource) Token() (*oauth2.Token, error) {
 	if err != nil {
 		return nil, err
 	}
-	stsRequest := STSTokenExchangeRequest{
+	stsRequest := stsTokenExchangeRequest{
 		GrantType:          "urn:ietf:params:oauth:grant-type:token-exchange",
 		Audience:           conf.Audience,
 		Scope:              conf.Scopes,
@@ -134,12 +134,12 @@ func (ts tokenSource) Token() (*oauth2.Token, error) {
 	}
 	header := make(http.Header)
 	header.Add("Content-Type", "application/x-www-form-urlencoded")
-	clientAuth := ClientAuthentication{
+	clientAuth := clientAuthentication{
 		AuthStyle:    oauth2.AuthStyleInHeader,
 		ClientID:     conf.ClientID,
 		ClientSecret: conf.ClientSecret,
 	}
-	stsResp, err := ExchangeToken(ts.ctx, conf.TokenURL, &stsRequest, clientAuth, header, nil)
+	stsResp, err := exchangeToken(ts.ctx, conf.TokenURL, &stsRequest, clientAuth, header, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/google/internal/externalaccount/clientauth.go
+++ b/google/internal/externalaccount/clientauth.go
@@ -11,15 +11,15 @@ import (
 	"net/url"
 )
 
-// ClientAuthentication represents an OAuth client ID and secret and the mechanism for passing these credentials as stated in rfc6749#2.3.1.
-type ClientAuthentication struct {
+// clientAuthentication represents an OAuth client ID and secret and the mechanism for passing these credentials as stated in rfc6749#2.3.1.
+type clientAuthentication struct {
 	// AuthStyle can be either basic or request-body
 	AuthStyle    oauth2.AuthStyle
 	ClientID     string
 	ClientSecret string
 }
 
-func (c *ClientAuthentication) InjectAuthentication(values url.Values, headers http.Header) {
+func (c *clientAuthentication) InjectAuthentication(values url.Values, headers http.Header) {
 	if c.ClientID == "" || c.ClientSecret == "" || values == nil || headers == nil {
 		return
 	}

--- a/google/internal/externalaccount/clientauth_test.go
+++ b/google/internal/externalaccount/clientauth_test.go
@@ -37,7 +37,7 @@ func TestClientAuthentication_InjectHeaderAuthentication(t *testing.T) {
 		"Content-Type": ContentType,
 	}
 
-	headerAuthentication := ClientAuthentication{
+	headerAuthentication := clientAuthentication{
 		AuthStyle:    oauth2.AuthStyleInHeader,
 		ClientID:     clientID,
 		ClientSecret: clientSecret,
@@ -79,7 +79,7 @@ func TestClientAuthentication_ParamsAuthentication(t *testing.T) {
 	headerP := http.Header{
 		"Content-Type": ContentType,
 	}
-	paramsAuthentication := ClientAuthentication{
+	paramsAuthentication := clientAuthentication{
 		AuthStyle:    oauth2.AuthStyleInParams,
 		ClientID:     clientID,
 		ClientSecret: clientSecret,

--- a/google/internal/externalaccount/sts_exchange.go
+++ b/google/internal/externalaccount/sts_exchange.go
@@ -18,11 +18,11 @@ import (
 	"golang.org/x/oauth2"
 )
 
-// ExchangeToken performs an oauth2 token exchange with the provided endpoint.
+// exchangeToken performs an oauth2 token exchange with the provided endpoint.
 // The first 4 fields are all mandatory.  headers can be used to pass additional
 // headers beyond the bare minimum required by the token exchange.  options can
 // be used to pass additional JSON-structured options to the remote server.
-func ExchangeToken(ctx context.Context, endpoint string, request *STSTokenExchangeRequest, authentication ClientAuthentication, headers http.Header, options map[string]interface{}) (*STSTokenExchangeResponse, error) {
+func exchangeToken(ctx context.Context, endpoint string, request *stsTokenExchangeRequest, authentication clientAuthentication, headers http.Header, options map[string]interface{}) (*stsTokenExchangeResponse, error) {
 
 	client := oauth2.NewClient(ctx, nil)
 
@@ -68,7 +68,7 @@ func ExchangeToken(ctx context.Context, endpoint string, request *STSTokenExchan
 	if c := resp.StatusCode; c < 200 || c > 299 {
 		return nil, fmt.Errorf("oauth2/google: status code %d: %s", c, body)
 	}
-	var stsResp STSTokenExchangeResponse
+	var stsResp stsTokenExchangeResponse
 	err = json.Unmarshal(body, &stsResp)
 	if err != nil {
 		return nil, fmt.Errorf("oauth2/google: failed to unmarshal response body from Secure Token Server: %v", err)
@@ -78,8 +78,8 @@ func ExchangeToken(ctx context.Context, endpoint string, request *STSTokenExchan
 	return &stsResp, nil
 }
 
-// STSTokenExchangeRequest contains fields necessary to make an oauth2 token exchange.
-type STSTokenExchangeRequest struct {
+// stsTokenExchangeRequest contains fields necessary to make an oauth2 token exchange.
+type stsTokenExchangeRequest struct {
 	ActingParty struct {
 		ActorToken     string
 		ActorTokenType string
@@ -93,8 +93,8 @@ type STSTokenExchangeRequest struct {
 	SubjectTokenType   string
 }
 
-// STSTokenExchangeResponse is used to decode the remote server response during an oauth2 token exchange.
-type STSTokenExchangeResponse struct {
+// stsTokenExchangeResponse is used to decode the remote server response during an oauth2 token exchange.
+type stsTokenExchangeResponse struct {
 	AccessToken     string `json:"access_token"`
 	IssuedTokenType string `json:"issued_token_type"`
 	TokenType       string `json:"token_type"`

--- a/google/internal/externalaccount/sts_exchange_test.go
+++ b/google/internal/externalaccount/sts_exchange_test.go
@@ -15,13 +15,13 @@ import (
 	"testing"
 )
 
-var auth = ClientAuthentication{
+var auth = clientAuthentication{
 	AuthStyle:    oauth2.AuthStyleInHeader,
 	ClientID:     clientID,
 	ClientSecret: clientSecret,
 }
 
-var tokenRequest = STSTokenExchangeRequest{
+var tokenRequest = stsTokenExchangeRequest{
 	ActingParty: struct {
 		ActorToken     string
 		ActorTokenType string
@@ -37,7 +37,7 @@ var tokenRequest = STSTokenExchangeRequest{
 
 var requestbody = "audience=32555940559.apps.googleusercontent.com&grant_type=urn%3Aietf%3Aparams%3Aoauth%3Agrant-type%3Atoken-exchange&requested_token_type=urn%3Aietf%3Aparams%3Aoauth%3Atoken-type%3Aaccess_token&scope=https%3A%2F%2Fwww.googleapis.com%2Fauth%2Fdevstorage.full_control&subject_token=Sample.Subject.Token&subject_token_type=urn%3Aietf%3Aparams%3Aoauth%3Atoken-type%3Ajwt"
 var responseBody = `{"access_token":"Sample.Access.Token","issued_token_type":"urn:ietf:params:oauth:token-type:access_token","token_type":"Bearer","expires_in":3600,"scope":"https://www.googleapis.com/auth/cloud-platform"}`
-var expectedToken = STSTokenExchangeResponse{
+var expectedToken = stsTokenExchangeResponse{
 	AccessToken:     "Sample.Access.Token",
 	IssuedTokenType: "urn:ietf:params:oauth:token-type:access_token",
 	TokenType:       "Bearer",
@@ -75,9 +75,9 @@ func TestExchangeToken(t *testing.T) {
 	headers := http.Header{}
 	headers.Add("Content-Type", "application/x-www-form-urlencoded")
 
-	resp, err := ExchangeToken(context.Background(), ts.URL, &tokenRequest, auth, headers, nil)
+	resp, err := exchangeToken(context.Background(), ts.URL, &tokenRequest, auth, headers, nil)
 	if err != nil {
-		t.Fatalf("ExchangeToken failed with error: %v", err)
+		t.Fatalf("exchangeToken failed with error: %v", err)
 	}
 
 	if expectedToken != *resp {
@@ -95,7 +95,7 @@ func TestExchangeToken_Err(t *testing.T) {
 
 	headers := http.Header{}
 	headers.Add("Content-Type", "application/x-www-form-urlencoded")
-	_, err := ExchangeToken(context.Background(), ts.URL, &tokenRequest, auth, headers, nil)
+	_, err := exchangeToken(context.Background(), ts.URL, &tokenRequest, auth, headers, nil)
 	if err == nil {
 		t.Errorf("Expected handled error; instead got nil.")
 	}
@@ -179,5 +179,5 @@ func TestExchangeToken_Opts(t *testing.T) {
 	inputOpts := make(map[string]interface{})
 	inputOpts["one"] = firstOption
 	inputOpts["two"] = secondOption
-	ExchangeToken(context.Background(), ts.URL, &tokenRequest, auth, headers, inputOpts)
+	exchangeToken(context.Background(), ts.URL, &tokenRequest, auth, headers, inputOpts)
 }


### PR DESCRIPTION
These structs and funcs cannot be used by the end consumer. Unexporting them helps cleans up our documentation