### PR TITLE
oauth2: document that provided context will be used in refresh requests.

### DIFF
--- a/clientcredentials/clientcredentials.go
+++ b/clientcredentials/clientcredentials.go
@@ -60,7 +60,9 @@ func (c *Config) Token(ctx context.Context) (*oauth2.Token, error) {
 // The token will auto-refresh as necessary.
 //
 // The provided context optionally controls which HTTP client
-// is returned. See the oauth2.HTTPClient variable.
+// is returned. See the oauth2.HTTPClient variable. It will be
+// used for all refresh requests for the life of the Config, so
+// do not pass a context with a deadline.
 //
 // The returned Client and its Transport should not be modified.
 func (c *Config) Client(ctx context.Context) *http.Client {

--- a/internal/token.go
+++ b/internal/token.go
@@ -231,7 +231,7 @@ func RetrieveToken(ctx context.Context, clientID, clientSecret, tokenURL string,
 func doTokenRoundTrip(ctx context.Context, req *http.Request) (*Token, error) {
 	r, err := ctxhttp.Do(ctx, ContextClient(ctx), req)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("oauth2: cannot fetch token: %w", err)
 	}
 	body, err := ioutil.ReadAll(io.LimitReader(r.Body, 1<<20))
 	r.Body.Close()


### PR DESCRIPTION
The context given to Client() will be stored and reused for token refreshes througout the life of the Config. If the context expires e.g. during application startup, refresh attempts will fail. Add documentation and annotate the errors around this case so it's clear that token refresh, not the actual request, is the problem.

Updates #388