### PR TITLE
google: Make sure time is always in UTC

### DIFF
--- a/google/internal/externalaccount/basecredentials.go
+++ b/google/internal/externalaccount/basecredentials.go
@@ -14,7 +14,9 @@ import (
 )
 
 // now aliases time.Now for testing
-var now = time.Now
+var now = func() time.Time {
+	return time.Now().UTC()
+}
 
 // Config stores the configuration for fetching tokens with external credentials.
 type Config struct {


### PR DESCRIPTION
If times are stored in different time zones, then we occasionally get heisenbugs about expired tokens