### PR TITLE
google: add external account documentation

### DIFF
--- a/google/doc.go
+++ b/google/doc.go
@@ -4,9 +4,9 @@
 
 // Package google provides support for making OAuth2 authorized and authenticated
 // HTTP requests to Google APIs. It supports the Web server flow, client-side
-// credentials, service accounts, external accounts (workload identity federation),
-// Google Compute Engine service accounts, Google App Engine service accounts and
-// workload identity federation from non-Google cloud platforms.
+// credentials, service accounts, Google Compute Engine service accounts, 
+// Google App Engine service accounts and workload identity federation
+// from non-Google cloud platforms.
 //
 // A brief overview of the package follows. For more information, please read
 // https://developers.google.com/accounts/docs/OAuth2

--- a/google/doc.go
+++ b/google/doc.go
@@ -4,7 +4,7 @@
 
 // Package google provides support for making OAuth2 authorized and authenticated
 // HTTP requests to Google APIs. It supports the Web server flow, client-side
-// credentials, service accounts, Google Compute Engine service accounts, 
+// credentials, service accounts, Google Compute Engine service accounts,
 // Google App Engine service accounts and workload identity federation
 // from non-Google cloud platforms.
 //

--- a/google/doc.go
+++ b/google/doc.go
@@ -4,9 +4,9 @@
 
 // Package google provides support for making OAuth2 authorized and authenticated
 // HTTP requests to Google APIs. It supports the Web server flow, client-side
-// credentials, service accounts, Google Compute Engine service accounts, Google
-// App Engine service accounts and workload identity federation from non-Google
-// cloud platforms.
+// credentials, service accounts, external accounts (workload identity federation),
+// Google Compute Engine service accounts, Google App Engine service accounts and
+// workload identity federation from non-Google cloud platforms.
 //
 // A brief overview of the package follows. For more information, please read
 // https://developers.google.com/accounts/docs/OAuth2

--- a/google/internal/externalaccount/basecredentials.go
+++ b/google/internal/externalaccount/basecredentials.go
@@ -17,45 +17,34 @@ import (
 var now = time.Now
 
 // Config stores the configuration for fetching tokens with external credentials:
-
-// Audience is the STS audience which contains the resource name for the workload
-// identity pool or the workforce pool and the provider identifier in that pool.
-
-// TokenURL is the STS token exchange endpoint.
-
-// TokenInfoURL is the token_info endpoint used to retrieve the account related information (
-// user attributes like account identifier, eg. email, username, uid, etc). This is
-// needed for gCloud session account identification.
-
-// SubjectTokenType is the STS token type based on the Oauth2.0 token exchange spec
-// e.g. `urn:ietf:params:oauth:token-type:jwt`
-
-// TokenURL is the STS token exchange endpoint
-
-// ServiceAccountImpersonationURL is the URL for the service account impersonation request. This is only
-// required for workload identity pools when APIs to be accessed have not integrated with UberMint.
-
-// Client ID and client secret are currently only required if token_info endpoint also
-// needs to be called with the generated GCP access token. When provided, STS will be
-// called with additional basic authentication using client_id as username and client_secret as password.
-
-// CredentialSource contains the necessary information to retrieve the token itself, as well
-// as some environmental information.
-
-// QuotaProjectID is injected by gCloud. If the value is non-empty, the Auth libraries
-// will set the x-goog-user-project which overrides the project associated with the credentials.
-
-// Scopes contains the desired scopes for the returned access token.
 type Config struct {
+	// Audience is the STS audience which contains the resource name for the workload
+	// identity pool or the workforce pool and the provider identifier in that pool.
 	Audience                       string
+	// SubjectTokenType is the STS token type based on the Oauth2.0 token exchange spec
+	// e.g. `urn:ietf:params:oauth:token-type:jwt`
 	SubjectTokenType               string
+	// TokenURL is the STS token exchange endpoint.
 	TokenURL                       string
+	// TokenInfoURL is the token_info endpoint used to retrieve the account related information (
+	// user attributes like account identifier, eg. email, username, uid, etc). This is
+	// needed for gCloud session account identification.
 	TokenInfoURL                   string
+	// ServiceAccountImpersonationURL is the URL for the service account impersonation request. This is only
+	// required for workload identity pools when APIs to be accessed have not integrated with UberMint.
 	ServiceAccountImpersonationURL string
+	// ClientID and ClientSecret are currently only required if token_info endpoint also
+	// needs to be called with the generated GCP access token. When provided, STS will be
+	// called with additional basic authentication using client_id as username and client_secret as password.
 	ClientSecret                   string
 	ClientID                       string
+	// CredentialSource contains the necessary information to retrieve the token itself, as well
+	// as some environmental information.
 	CredentialSource               CredentialSource
+	// QuotaProjectID is injected by gCloud. If the value is non-empty, the Auth libraries
+	// will set the x-goog-user-project which overrides the project associated with the credentials.
 	QuotaProjectID                 string
+	// Scopes contains the desired scopes for the returned access token.
 	Scopes                         []string
 }
 

--- a/google/internal/externalaccount/basecredentials.go
+++ b/google/internal/externalaccount/basecredentials.go
@@ -16,7 +16,36 @@ import (
 // now aliases time.Now for testing
 var now = time.Now
 
-// Config stores the configuration for fetching tokens with external credentials.
+// Config stores the configuration for fetching tokens with external credentials:
+
+// Audience is the STS audience which contains the resource name for the workload
+// identity pool or the workforce pool and the provider identifier in that pool.
+
+// TokenURL is the STS token exchange endpoint.
+
+// TokenInfoURL is the token_info endpoint used to retrieve the account related information (
+// user attributes like account identifier, eg. email, username, uid, etc). This is
+// needed for gCloud session account identification.
+
+// SubjectTokenType is the STS token type based on the Oauth2.0 token exchange spec
+// e.g. `urn:ietf:params:oauth:token-type:jwt`
+
+// TokenURL is the STS token exchange endpoint
+
+// ServiceAccountImpersonationURL is the URL for the service account impersonation request. This is only
+// required for workload identity pools when APIs to be accessed have not integrated with UberMint.
+
+// Client ID and client secret are currently only required if token_info endpoint also
+// needs to be called with the generated GCP access token. When provided, STS will be
+// called with additional basic authentication using client_id as username and client_secret as password.
+
+// CredentialSource contains the necessary information to retrieve the token itself, as well
+// as some environmental information.
+
+// QuotaProjectID is injected by gCloud. If the value is non-empty, the Auth libraries
+// will set the x-goog-user-project which overrides the project associated with the credentials.
+
+// Scopes contains the desired scopes for the returned access token.
 type Config struct {
 	Audience                       string
 	SubjectTokenType               string
@@ -64,6 +93,8 @@ type format struct {
 }
 
 // CredentialSource stores the information necessary to retrieve the credentials for the STS exchange.
+// Either the File or the URL field should be filled, depending on the kind of credential in question.
+// The EnvironmentID should start with AWS if being used for an AWS credential.
 type CredentialSource struct {
 	File string `json:"file"`
 
@@ -105,7 +136,7 @@ type baseCredentialSource interface {
 	subjectToken() (string, error)
 }
 
-// tokenSource is the source that handles external credentials.
+// tokenSource is the source that handles external credentials.  It is used to retrieve Tokens.
 type tokenSource struct {
 	ctx  context.Context
 	conf *Config

--- a/google/internal/externalaccount/basecredentials.go
+++ b/google/internal/externalaccount/basecredentials.go
@@ -16,13 +16,13 @@ import (
 // now aliases time.Now for testing
 var now = time.Now
 
-// Config stores the configuration for fetching tokens with external credentials:
+// Config stores the configuration for fetching tokens with external credentials.
 type Config struct {
-	// Audience is the STS audience which contains the resource name for the workload
+	// Audience is the Secure Token Service (STS) audience which contains the resource name for the workload
 	// identity pool or the workforce pool and the provider identifier in that pool.
 	Audience                       string
 	// SubjectTokenType is the STS token type based on the Oauth2.0 token exchange spec
-	// e.g. `urn:ietf:params:oauth:token-type:jwt`
+	// e.g. `urn:ietf:params:oauth:token-type:jwt`.
 	SubjectTokenType               string
 	// TokenURL is the STS token exchange endpoint.
 	TokenURL                       string
@@ -33,10 +33,11 @@ type Config struct {
 	// ServiceAccountImpersonationURL is the URL for the service account impersonation request. This is only
 	// required for workload identity pools when APIs to be accessed have not integrated with UberMint.
 	ServiceAccountImpersonationURL string
-	// ClientID and ClientSecret are currently only required if token_info endpoint also
+	// ClientSecret is currently only required if token_info endpoint also
 	// needs to be called with the generated GCP access token. When provided, STS will be
 	// called with additional basic authentication using client_id as username and client_secret as password.
 	ClientSecret                   string
+	// ClientID is only required in conjunction with ClientSecret, as described above.
 	ClientID                       string
 	// CredentialSource contains the necessary information to retrieve the token itself, as well
 	// as some environmental information.

--- a/google/internal/externalaccount/clientauth.go
+++ b/google/internal/externalaccount/clientauth.go
@@ -19,7 +19,7 @@ type clientAuthentication struct {
 	ClientSecret string
 }
 
-// InjectAuthentication is simply used to add authentication to a Secure Token Service exchange
+// InjectAuthentication is used to add authentication to a Secure Token Service exchange
 // request.  It modifies either the passed url.Values or http.Header depending on the desired
 // authentication format.
 func (c *clientAuthentication) InjectAuthentication(values url.Values, headers http.Header) {

--- a/google/internal/externalaccount/clientauth.go
+++ b/google/internal/externalaccount/clientauth.go
@@ -19,6 +19,9 @@ type clientAuthentication struct {
 	ClientSecret string
 }
 
+// InjectAuthentication is simply used to add authentication to a Secure Token Service exchange
+// request.  It modifies either the passed url.Values or http.Header depending on the desired
+// authentication format.
 func (c *clientAuthentication) InjectAuthentication(values url.Values, headers http.Header) {
 	if c.ClientID == "" || c.ClientSecret == "" || values == nil || headers == nil {
 		return

--- a/google/internal/externalaccount/impersonate.go
+++ b/google/internal/externalaccount/impersonate.go
@@ -36,7 +36,7 @@ type impersonateTokenSource struct {
 	scopes []string
 }
 
-// Token performs the exchange to get a temporary service account
+// Token performs the exchange to get a temporary service account token to allow access to GCP.
 func (its impersonateTokenSource) Token() (*oauth2.Token, error) {
 	reqBody := generateAccessTokenReq{
 		Lifetime: "3600s",


### PR DESCRIPTION
Adds some documentation to existing public structures for third-party authentication.