### PR TITLE
impersonate: fix syntax error on build

### DIFF
--- a/google/internal/externalaccount/aws.go
+++ b/google/internal/externalaccount/aws.go
@@ -341,6 +341,8 @@ func (cs awsCredentialSource) subjectToken() (string, error) {
 func (cs *awsCredentialSource) getRegion() (string, error) {
 	if envAwsRegion := getenv("AWS_REGION"); envAwsRegion != "" {
 		return envAwsRegion, nil
+	} else if envAwsRegion := getenv("AWS_DEFAULT_REGION"); envAwsRegion != "" {
+		return envAwsRegion, nil
 	}
 
 	if cs.RegionURL == "" {

--- a/google/internal/externalaccount/aws.go
+++ b/google/internal/externalaccount/aws.go
@@ -341,7 +341,8 @@ func (cs awsCredentialSource) subjectToken() (string, error) {
 func (cs *awsCredentialSource) getRegion() (string, error) {
 	if envAwsRegion := getenv("AWS_REGION"); envAwsRegion != "" {
 		return envAwsRegion, nil
-	} if envAwsRegion := getenv("AWS_DEFAULT_REGION"); envAwsRegion != "" {
+	}
+	if envAwsRegion := getenv("AWS_DEFAULT_REGION"); envAwsRegion != "" {
 		return envAwsRegion, nil
 	}
 

--- a/google/internal/externalaccount/aws.go
+++ b/google/internal/externalaccount/aws.go
@@ -341,7 +341,7 @@ func (cs awsCredentialSource) subjectToken() (string, error) {
 func (cs *awsCredentialSource) getRegion() (string, error) {
 	if envAwsRegion := getenv("AWS_REGION"); envAwsRegion != "" {
 		return envAwsRegion, nil
-	} else if envAwsRegion := getenv("AWS_DEFAULT_REGION"); envAwsRegion != "" {
+	} if envAwsRegion := getenv("AWS_DEFAULT_REGION"); envAwsRegion != "" {
 		return envAwsRegion, nil
 	}
 

--- a/google/internal/externalaccount/urlcredsource_test.go
+++ b/google/internal/externalaccount/urlcredsource_test.go
@@ -7,7 +7,6 @@ package externalaccount
 import (
 	"context"
 	"encoding/json"
-	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -20,7 +19,6 @@ func TestRetrieveURLSubjectToken_Text(t *testing.T) {
 		if r.Method != "GET" {
 			t.Errorf("Unexpected request method, %v is found", r.Method)
 		}
-		fmt.Println(r.Header)
 		if r.Header.Get("Metadata") != "True" {
 			t.Errorf("Metadata header not properly included.")
 		}


### PR DESCRIPTION
Fixes a syntax error caused by an improperly formatted if statement.