### PR TITLE
#515: impersonated service account

### DIFF
--- a/google/google.go
+++ b/google/google.go
@@ -92,9 +92,10 @@ func JWTConfigFromJSON(jsonKey []byte, scope ...string) (*jwt.Config, error) {
 
 // JSON key file types.
 const (
-	serviceAccountKey  = "service_account"
-	userCredentialsKey = "authorized_user"
-	externalAccountKey = "external_account"
+	serviceAccountKey          = "service_account"
+	userCredentialsKey         = "authorized_user"
+	externalAccountKey         = "external_account"
+	impersonatedServiceAccount = "impersonated_service_account"
 )
 
 // credentialsFile is the unmarshalled representation of a credentials file.
@@ -123,6 +124,9 @@ type credentialsFile struct {
 	ServiceAccountImpersonationURL string                           `json:"service_account_impersonation_url"`
 	CredentialSource               externalaccount.CredentialSource `json:"credential_source"`
 	QuotaProjectID                 string                           `json:"quota_project_id"`
+
+	// Service account impersonation
+	SourceCredentials *credentialsFile `json:"source_credentials"`
 }
 
 func (f *credentialsFile) jwtConfig(scopes []string, subject string) *jwt.Config {
@@ -178,6 +182,23 @@ func (f *credentialsFile) tokenSource(ctx context.Context, params CredentialsPar
 			Scopes:                         params.Scopes,
 		}
 		return cfg.TokenSource(ctx)
+	case impersonatedServiceAccount:
+		if f.SourceCredentials == nil {
+			return nil, errors.New("missing 'source_credentials' field in credentials")
+		}
+
+		sourceToken, err := f.SourceCredentials.tokenSource(ctx, params)
+		if err != nil {
+			return nil, err
+		}
+		imp := externalaccount.ImpersonateTokenSource{
+			Ctx:    ctx,
+			Url:    f.ServiceAccountImpersonationURL,
+			Scopes: params.Scopes,
+			Ts:     oauth2.ReuseTokenSource(nil, sourceToken),
+			// Delegates?? -> I don't know how to manage and how to use them here
+		}
+		return oauth2.ReuseTokenSource(nil, imp), nil
 	case "":
 		return nil, errors.New("missing 'type' field in credentials")
 	default:

--- a/google/internal/externalaccount/basecredentials.go
+++ b/google/internal/externalaccount/basecredentials.go
@@ -124,11 +124,11 @@ func (c *Config) tokenSource(ctx context.Context, tokenURLValidPats []*regexp.Re
 	}
 	scopes := c.Scopes
 	ts.conf.Scopes = []string{"https://www.googleapis.com/auth/cloud-platform"}
-	imp := impersonateTokenSource{
-		ctx:    ctx,
-		url:    c.ServiceAccountImpersonationURL,
-		scopes: scopes,
-		ts:     oauth2.ReuseTokenSource(nil, ts),
+	imp := ImpersonateTokenSource{
+		Ctx:    ctx,
+		Url:    c.ServiceAccountImpersonationURL,
+		Scopes: scopes,
+		Ts:     oauth2.ReuseTokenSource(nil, ts),
 	}
 	return oauth2.ReuseTokenSource(nil, imp), nil
 }

--- a/google/internal/externalaccount/impersonate.go
+++ b/google/internal/externalaccount/impersonate.go
@@ -29,11 +29,17 @@ type impersonateTokenResponse struct {
 	ExpireTime  string `json:"expireTime"`
 }
 
+// ImpersonateTokenSource uses a source credential, stored in Ts, to request an access token to the provided Url
+// Scopes can be defined when the access token is requested.
 type ImpersonateTokenSource struct {
+	// execution context
 	Ctx context.Context
-	Ts  oauth2.TokenSource
+	// source credential
+	Ts oauth2.TokenSource
 
-	Url    string
+	// impersonation url to request an access token
+	Url string
+	// scopes to include in the access token request
 	Scopes []string
 }
 

--- a/google/internal/externalaccount/impersonate.go
+++ b/google/internal/externalaccount/impersonate.go
@@ -29,30 +29,30 @@ type impersonateTokenResponse struct {
 	ExpireTime  string `json:"expireTime"`
 }
 
-type impersonateTokenSource struct {
-	ctx context.Context
-	ts  oauth2.TokenSource
+type ImpersonateTokenSource struct {
+	Ctx context.Context
+	Ts  oauth2.TokenSource
 
-	url    string
-	scopes []string
+	Url    string
+	Scopes []string
 }
 
 // Token performs the exchange to get a temporary service account token to allow access to GCP.
-func (its impersonateTokenSource) Token() (*oauth2.Token, error) {
+func (its ImpersonateTokenSource) Token() (*oauth2.Token, error) {
 	reqBody := generateAccessTokenReq{
 		Lifetime: "3600s",
-		Scope:    its.scopes,
+		Scope:    its.Scopes,
 	}
 	b, err := json.Marshal(reqBody)
 	if err != nil {
 		return nil, fmt.Errorf("oauth2/google: unable to marshal request: %v", err)
 	}
-	client := oauth2.NewClient(its.ctx, its.ts)
-	req, err := http.NewRequest("POST", its.url, bytes.NewReader(b))
+	client := oauth2.NewClient(its.Ctx, its.Ts)
+	req, err := http.NewRequest("POST", its.Url, bytes.NewReader(b))
 	if err != nil {
 		return nil, fmt.Errorf("oauth2/google: unable to create impersonation request: %v", err)
 	}
-	req = req.WithContext(its.ctx)
+	req = req.WithContext(its.Ctx)
 	req.Header.Set("Content-Type", "application/json")
 
 	resp, err := client.Do(req)


### PR DESCRIPTION
Implementation proposal of #515 

Reuse of `ImpersonateTokenSource` struct, from `google/internal/externalaccount/Impersonate.go' file, turns it public. Could be a concern and a new design could be though.

No unit test, seems not relevant compared to the existing ones.

Comments on the public struct `ImpersonateTokenSource` can be improved. I'm open to any comments.