### PR TITLE
Make expiryDelta configurable

### DIFF
--- a/token.go
+++ b/token.go
@@ -19,7 +19,12 @@ import (
 // expiryDelta determines how earlier a token should be considered
 // expired than its actual expiration time. It is used to avoid late
 // expirations due to client-server time mismatches.
-const expiryDelta = 10 * time.Second
+var expiryDelta = 10 * time.Second
+
+// make expiryDelta configurable
+func SetExpiryDelta(seconds int){
+	expiryDelta = time.Duration(seconds) * time.Second
+}
 
 // Token represents the credentials used to authorize
 // the requests to access protected resources on the OAuth 2.0


### PR DESCRIPTION
In some use cases, the hardcoded expiryDelta of 10 seconds is too little. Requests can currently be sent when the access token expires anywhere right above 10 seconds, which can result in access tokens expiring before they have the chance to be verified by the recipient - and so the request is discarded. Several people have asked about the possibility of increasing this over the years ([issue 249](https://github.com/golang/oauth2/issues/249), [issue 481](https://github.com/golang/oauth2/issues/481), [PR 359](https://github.com/golang/oauth2/pull/359)), so making it configurable would be a nice change I think. This is also a non-intrusive addition that does not affect any existing code or tests.