### PR TITLE
endpoints: update Facebook endpoints

### DIFF
--- a/endpoints/endpoints.go
+++ b/endpoints/endpoints.go
@@ -37,8 +37,8 @@ var Cern = oauth2.Endpoint{
 
 // Facebook is the endpoint for Facebook.
 var Facebook = oauth2.Endpoint{
-	AuthURL:  "https://www.facebook.com/v3.2/dialog/oauth",
-	TokenURL: "https://graph.facebook.com/v3.2/oauth/access_token",
+	AuthURL:  "https://www.facebook.com/v12.0/dialog/oauth",
+	TokenURL: "https://graph.facebook.com/v12.0/oauth/access_token",
 }
 
 // Foursquare is the endpoint for Foursquare.

--- a/endpoints/endpoints.go
+++ b/endpoints/endpoints.go
@@ -37,8 +37,8 @@ var Cern = oauth2.Endpoint{
 
 // Facebook is the endpoint for Facebook.
 var Facebook = oauth2.Endpoint{
-	AuthURL:  "https://www.facebook.com/v12.0/dialog/oauth",
-	TokenURL: "https://graph.facebook.com/v12.0/oauth/access_token",
+	AuthURL:  "https://www.facebook.com/dialog/oauth",
+	TokenURL: "https://graph.facebook.com/oauth/access_token",
 }
 
 // Foursquare is the endpoint for Foursquare.

--- a/facebook/facebook.go
+++ b/facebook/facebook.go
@@ -11,6 +11,6 @@ import (
 
 // Endpoint is Facebook's OAuth 2.0 endpoint.
 var Endpoint = oauth2.Endpoint{
-	AuthURL:  "https://www.facebook.com/v12.0/dialog/oauth",
-	TokenURL: "https://graph.facebook.com/v12.0/oauth/access_token",
+	AuthURL:  "https://www.facebook.com/dialog/oauth",
+	TokenURL: "https://graph.facebook.com/oauth/access_token",
 }

--- a/facebook/facebook.go
+++ b/facebook/facebook.go
@@ -11,6 +11,6 @@ import (
 
 // Endpoint is Facebook's OAuth 2.0 endpoint.
 var Endpoint = oauth2.Endpoint{
-	AuthURL:  "https://www.facebook.com/v3.2/dialog/oauth",
-	TokenURL: "https://graph.facebook.com/v3.2/oauth/access_token",
+	AuthURL:  "https://www.facebook.com/v12.0/dialog/oauth",
+	TokenURL: "https://graph.facebook.com/v12.0/oauth/access_token",
 }


### PR DESCRIPTION
After `May 4th, 2021`, Facebook graph api version 3.2 has been stop service. Need update to use link without version tag.

Refer: https://developers.facebook.com/docs/graph-api/changelog/version3.2