### PR TITLE
google/externalaccount: add support for workforce pool credentials

### DIFF
--- a/google/google.go
+++ b/google/google.go
@@ -123,7 +123,7 @@ type credentialsFile struct {
 	ServiceAccountImpersonationURL string                           `json:"service_account_impersonation_url"`
 	CredentialSource               externalaccount.CredentialSource `json:"credential_source"`
 	QuotaProjectID                 string                           `json:"quota_project_id"`
-	WorkforcePoolUserProject 			 string														`json:"workforce_pool_user_project"`
+	WorkforcePoolUserProject       string                           `json:"workforce_pool_user_project"`
 }
 
 func (f *credentialsFile) jwtConfig(scopes []string, subject string) *jwt.Config {
@@ -177,7 +177,7 @@ func (f *credentialsFile) tokenSource(ctx context.Context, params CredentialsPar
 			CredentialSource:               f.CredentialSource,
 			QuotaProjectID:                 f.QuotaProjectID,
 			Scopes:                         params.Scopes,
-			WorkforcePoolUserProject:				f.WorkforcePoolUserProject,
+			WorkforcePoolUserProject:       f.WorkforcePoolUserProject,
 		}
 		return cfg.TokenSource(ctx)
 	case "":

--- a/google/google.go
+++ b/google/google.go
@@ -123,6 +123,7 @@ type credentialsFile struct {
 	ServiceAccountImpersonationURL string                           `json:"service_account_impersonation_url"`
 	CredentialSource               externalaccount.CredentialSource `json:"credential_source"`
 	QuotaProjectID                 string                           `json:"quota_project_id"`
+	WorkforcePoolUserProject 			 string														`json:"workforce_pool_user_project"`
 }
 
 func (f *credentialsFile) jwtConfig(scopes []string, subject string) *jwt.Config {
@@ -176,6 +177,7 @@ func (f *credentialsFile) tokenSource(ctx context.Context, params CredentialsPar
 			CredentialSource:               f.CredentialSource,
 			QuotaProjectID:                 f.QuotaProjectID,
 			Scopes:                         params.Scopes,
+			WorkforcePoolUserProject:				f.WorkforcePoolUserProject,
 		}
 		return cfg.TokenSource(ctx)
 	case "":

--- a/google/internal/externalaccount/basecredentials.go
+++ b/google/internal/externalaccount/basecredentials.go
@@ -127,7 +127,7 @@ func (c *Config) tokenSource(ctx context.Context, tokenURLValidPats []*regexp.Re
 	if c.WorkforcePoolUserProject != "" {
 		valid := validateWorkforceAudience(c.Audience)
 		if !valid {
-			return nil, fmt.Errorf("oauth2/google: invalid Workforce Pool Audience provided while constructing tokenSource")
+			return nil, fmt.Errorf("oauth2/google: workforce_pool_user_project should not be set for non-workforce pool credentials")
 		}
 	}
 
@@ -241,7 +241,9 @@ func (ts tokenSource) Token() (*oauth2.Token, error) {
 		ClientSecret: conf.ClientSecret,
 	}
 	var options map[string]interface{}
-	if conf.WorkforcePoolUserProject != "" {
+	// Do not pass workforce_pool_user_project when client authentication is used.
+	// The client ID is sufficient for determining the user project.
+	if conf.WorkforcePoolUserProject != "" && conf.ClientID == "" {
 		options = map[string]interface{}{
 			"userProject": conf.WorkforcePoolUserProject,
 		}

--- a/google/internal/externalaccount/basecredentials_test.go
+++ b/google/internal/externalaccount/basecredentials_test.go
@@ -12,6 +12,8 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"golang.org/x/oauth2"
 )
 
 const (
@@ -35,55 +37,64 @@ var testConfig = Config{
 }
 
 var (
-	baseCredsRequestBody           = "audience=32555940559.apps.googleusercontent.com&grant_type=urn%3Aietf%3Aparams%3Aoauth%3Agrant-type%3Atoken-exchange&requested_token_type=urn%3Aietf%3Aparams%3Aoauth%3Atoken-type%3Aaccess_token&scope=https%3A%2F%2Fwww.googleapis.com%2Fauth%2Fdevstorage.full_control&subject_token=street123&subject_token_type=urn%3Aietf%3Aparams%3Aoauth%3Atoken-type%3Ajwt"
-	baseCredsResponseBody          = `{"access_token":"Sample.Access.Token","issued_token_type":"urn:ietf:params:oauth:token-type:access_token","token_type":"Bearer","expires_in":3600,"scope":"https://www.googleapis.com/auth/cloud-platform"}`
-	workforcePoolRequestBody       = "audience=%2F%2Fiam.googleapis.com%2Flocations%2Feu%2FworkforcePools%2Fpool-id%2Fproviders%2Fprovider-id&grant_type=urn%3Aietf%3Aparams%3Aoauth%3Agrant-type%3Atoken-exchange&options=%7B%22userProject%22%3A%22myProject%22%7D&requested_token_type=urn%3Aietf%3Aparams%3Aoauth%3Atoken-type%3Aaccess_token&scope=https%3A%2F%2Fwww.googleapis.com%2Fauth%2Fdevstorage.full_control&subject_token=street123&subject_token_type=urn%3Aietf%3Aparams%3Aoauth%3Atoken-type%3Ajwt"
-	correctAT                      = "Sample.Access.Token"
-	expiry                   int64 = 234852
+	baseCredsRequestBody                          = "audience=32555940559.apps.googleusercontent.com&grant_type=urn%3Aietf%3Aparams%3Aoauth%3Agrant-type%3Atoken-exchange&requested_token_type=urn%3Aietf%3Aparams%3Aoauth%3Atoken-type%3Aaccess_token&scope=https%3A%2F%2Fwww.googleapis.com%2Fauth%2Fdevstorage.full_control&subject_token=street123&subject_token_type=urn%3Aietf%3Aparams%3Aoauth%3Atoken-type%3Ajwt"
+	baseCredsResponseBody                         = `{"access_token":"Sample.Access.Token","issued_token_type":"urn:ietf:params:oauth:token-type:access_token","token_type":"Bearer","expires_in":3600,"scope":"https://www.googleapis.com/auth/cloud-platform"}`
+	workforcePoolRequestBodyWithClientId          = "audience=%2F%2Fiam.googleapis.com%2Flocations%2Feu%2FworkforcePools%2Fpool-id%2Fproviders%2Fprovider-id&grant_type=urn%3Aietf%3Aparams%3Aoauth%3Agrant-type%3Atoken-exchange&requested_token_type=urn%3Aietf%3Aparams%3Aoauth%3Atoken-type%3Aaccess_token&scope=https%3A%2F%2Fwww.googleapis.com%2Fauth%2Fdevstorage.full_control&subject_token=street123&subject_token_type=urn%3Aietf%3Aparams%3Aoauth%3Atoken-type%3Ajwt"
+	workforcePoolRequestBodyWithoutClientId       = "audience=%2F%2Fiam.googleapis.com%2Flocations%2Feu%2FworkforcePools%2Fpool-id%2Fproviders%2Fprovider-id&grant_type=urn%3Aietf%3Aparams%3Aoauth%3Agrant-type%3Atoken-exchange&options=%7B%22userProject%22%3A%22myProject%22%7D&requested_token_type=urn%3Aietf%3Aparams%3Aoauth%3Atoken-type%3Aaccess_token&scope=https%3A%2F%2Fwww.googleapis.com%2Fauth%2Fdevstorage.full_control&subject_token=street123&subject_token_type=urn%3Aietf%3Aparams%3Aoauth%3Atoken-type%3Ajwt"
+	correctAT                                     = "Sample.Access.Token"
+	expiry                                  int64 = 234852
 )
 var (
 	testNow = func() time.Time { return time.Unix(expiry, 0) }
 )
 
-func TestToken(t *testing.T) {
-	targetServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if got, want := r.URL.String(), "/"; got != want {
+type testExchangeTokenServer struct {
+	url           string
+	authorization string
+	contentType   string
+	body          string
+	response      string
+}
+
+func run(t *testing.T, config *Config, tets *testExchangeTokenServer) (*oauth2.Token, error) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got, want := r.URL.String(), tets.url; got != want {
 			t.Errorf("URL.String(): got %v but want %v", got, want)
 		}
 		headerAuth := r.Header.Get("Authorization")
-		if got, want := headerAuth, "Basic cmJyZ25vZ25yaG9uZ28zYmk0Z2I5Z2hnOWc6bm90c29zZWNyZXQ="; got != want {
+		if got, want := headerAuth, tets.authorization; got != want {
 			t.Errorf("got %v but want %v", got, want)
 		}
 		headerContentType := r.Header.Get("Content-Type")
-		if got, want := headerContentType, "application/x-www-form-urlencoded"; got != want {
+		if got, want := headerContentType, tets.contentType; got != want {
 			t.Errorf("got %v but want %v", got, want)
 		}
 		body, err := ioutil.ReadAll(r.Body)
 		if err != nil {
 			t.Fatalf("Failed reading request body: %s.", err)
 		}
-		if got, want := string(body), baseCredsRequestBody; got != want {
+		if got, want := string(body), tets.body; got != want {
 			t.Errorf("Unexpected exchange payload: got %v but want %v", got, want)
 		}
 		w.Header().Set("Content-Type", "application/json")
-		w.Write([]byte(baseCredsResponseBody))
+		w.Write([]byte(tets.response))
 	}))
-	defer targetServer.Close()
-
-	testConfig.TokenURL = targetServer.URL
-	ourTS := tokenSource{
-		ctx:  context.Background(),
-		conf: &testConfig,
-	}
+	defer server.Close()
+	config.TokenURL = server.URL
 
 	oldNow := now
 	defer func() { now = oldNow }()
 	now = testNow
 
-	tok, err := ourTS.Token()
-	if err != nil {
-		t.Fatalf("Unexpected error: %e", err)
+	ts := tokenSource{
+		ctx:  context.Background(),
+		conf: config,
 	}
+
+	return ts.Token()
+}
+
+func validateToken(t *testing.T, tok *oauth2.Token) {
 	if got, want := tok.AccessToken, correctAT; got != want {
 		t.Errorf("Unexpected access token: got %v, but wanted %v", got, want)
 	}
@@ -91,61 +102,113 @@ func TestToken(t *testing.T) {
 		t.Errorf("Unexpected TokenType: got %v, but wanted %v", got, want)
 	}
 
-	if got, want := tok.Expiry, now().Add(time.Duration(3600)*time.Second); got != want {
+	if got, want := tok.Expiry, testNow().Add(time.Duration(3600)*time.Second); got != want {
 		t.Errorf("Unexpected Expiry: got %v, but wanted %v", got, want)
 	}
 }
 
-func TestWorkforcePoolToken(t *testing.T) {
-	targetServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if got, want := r.URL.String(), "/"; got != want {
-			t.Errorf("URL.String(): got %v but want %v", got, want)
-		}
-		headerAuth := r.Header.Get("Authorization")
-		if got, want := headerAuth, "Basic cmJyZ25vZ25yaG9uZ28zYmk0Z2I5Z2hnOWc6bm90c29zZWNyZXQ="; got != want {
-			t.Errorf("got %v but want %v", got, want)
-		}
-		headerContentType := r.Header.Get("Content-Type")
-		if got, want := headerContentType, "application/x-www-form-urlencoded"; got != want {
-			t.Errorf("got %v but want %v", got, want)
-		}
-		body, err := ioutil.ReadAll(r.Body)
-		if err != nil {
-			t.Fatalf("Failed reading request body: %s.", err)
-		}
-		if got, want := string(body), workforcePoolRequestBody; got != want {
-			t.Errorf("Unexpected exchange payload: got %v but want %v", got, want)
-		}
-		w.Header().Set("Content-Type", "application/json")
-		w.Write([]byte(baseCredsResponseBody))
-	}))
-	defer targetServer.Close()
-
-	testConfig.TokenURL = targetServer.URL
-	testConfig.WorkforcePoolUserProject = "myProject"
-	testConfig.Audience = "//iam.googleapis.com/locations/eu/workforcePools/pool-id/providers/provider-id"
-	ourTS := tokenSource{
-		ctx:  context.Background(),
-		conf: &testConfig,
+func TestToken(t *testing.T) {
+	config := Config{
+		Audience:         "32555940559.apps.googleusercontent.com",
+		SubjectTokenType: "urn:ietf:params:oauth:token-type:jwt",
+		TokenInfoURL:     "http://localhost:8080/v1/tokeninfo",
+		ClientSecret:     "notsosecret",
+		ClientID:         "rbrgnognrhongo3bi4gb9ghg9g",
+		CredentialSource: testBaseCredSource,
+		Scopes:           []string{"https://www.googleapis.com/auth/devstorage.full_control"},
 	}
 
-	oldNow := now
-	defer func() { now = oldNow }()
-	now = testNow
+	server := testExchangeTokenServer{
+		url:           "/",
+		authorization: "Basic cmJyZ25vZ25yaG9uZ28zYmk0Z2I5Z2hnOWc6bm90c29zZWNyZXQ=",
+		contentType:   "application/x-www-form-urlencoded",
+		body:          baseCredsRequestBody,
+		response:      baseCredsResponseBody,
+	}
 
-	tok, err := ourTS.Token()
+	tok, err := run(t, &config, &server)
+
 	if err != nil {
 		t.Fatalf("Unexpected error: %e", err)
 	}
-	if got, want := tok.AccessToken, correctAT; got != want {
-		t.Errorf("Unexpected access token: got %v, but wanted %v", got, want)
-	}
-	if got, want := tok.TokenType, "Bearer"; got != want {
-		t.Errorf("Unexpected TokenType: got %v, but wanted %v", got, want)
+	validateToken(t, tok)
+}
+
+func TestWorkforcePoolTokenWithClientID(t *testing.T) {
+	config := Config{
+		Audience:                 "//iam.googleapis.com/locations/eu/workforcePools/pool-id/providers/provider-id",
+		SubjectTokenType:         "urn:ietf:params:oauth:token-type:jwt",
+		TokenInfoURL:             "http://localhost:8080/v1/tokeninfo",
+		ClientSecret:             "notsosecret",
+		ClientID:                 "rbrgnognrhongo3bi4gb9ghg9g",
+		CredentialSource:         testBaseCredSource,
+		Scopes:                   []string{"https://www.googleapis.com/auth/devstorage.full_control"},
+		WorkforcePoolUserProject: "myProject",
 	}
 
-	if got, want := tok.Expiry, now().Add(time.Duration(3600)*time.Second); got != want {
-		t.Errorf("Unexpected Expiry: got %v, but wanted %v", got, want)
+	server := testExchangeTokenServer{
+		url:           "/",
+		authorization: "Basic cmJyZ25vZ25yaG9uZ28zYmk0Z2I5Z2hnOWc6bm90c29zZWNyZXQ=",
+		contentType:   "application/x-www-form-urlencoded",
+		body:          workforcePoolRequestBodyWithClientId,
+		response:      baseCredsResponseBody,
+	}
+
+	tok, err := run(t, &config, &server)
+
+	if err != nil {
+		t.Fatalf("Unexpected error: %e", err)
+	}
+	validateToken(t, tok)
+}
+
+func TestWorkforcePoolTokenWithoutClientID(t *testing.T) {
+	config := Config{
+		Audience:                 "//iam.googleapis.com/locations/eu/workforcePools/pool-id/providers/provider-id",
+		SubjectTokenType:         "urn:ietf:params:oauth:token-type:jwt",
+		TokenInfoURL:             "http://localhost:8080/v1/tokeninfo",
+		ClientSecret:             "notsosecret",
+		CredentialSource:         testBaseCredSource,
+		Scopes:                   []string{"https://www.googleapis.com/auth/devstorage.full_control"},
+		WorkforcePoolUserProject: "myProject",
+	}
+
+	server := testExchangeTokenServer{
+		url:           "/",
+		authorization: "",
+		contentType:   "application/x-www-form-urlencoded",
+		body:          workforcePoolRequestBodyWithoutClientId,
+		response:      baseCredsResponseBody,
+	}
+
+	tok, err := run(t, &config, &server)
+
+	if err != nil {
+		t.Fatalf("Unexpected error: %e", err)
+	}
+	validateToken(t, tok)
+}
+
+func TestNonworkforceWithWorkforcePoolUserProject(t *testing.T) {
+	config := Config{
+		Audience:                 "32555940559.apps.googleusercontent.com",
+		SubjectTokenType:         "urn:ietf:params:oauth:token-type:jwt",
+		TokenInfoURL:             "http://localhost:8080/v1/tokeninfo",
+		TokenURL:                 "https://sts.googleapis.com",
+		ClientSecret:             "notsosecret",
+		ClientID:                 "rbrgnognrhongo3bi4gb9ghg9g",
+		CredentialSource:         testBaseCredSource,
+		Scopes:                   []string{"https://www.googleapis.com/auth/devstorage.full_control"},
+		WorkforcePoolUserProject: "myProject",
+	}
+
+	_, err := config.TokenSource(context.Background())
+
+	if err == nil {
+		t.Fatalf("Expected error but found none")
+	}
+	if got, want := err.Error(), "oauth2/google: workforce_pool_user_project should not be set for non-workforce pool credentials"; got != want {
+		t.Errorf("Incorrect error received.\nExpected: %s\nRecieved: %s", want, got)
 	}
 }
 

--- a/google/internal/externalaccount/basecredentials_test.go
+++ b/google/internal/externalaccount/basecredentials_test.go
@@ -37,10 +37,10 @@ var testConfig = Config{
 }
 
 var (
-	baseCredsRequestBody                          = "audience=32555940559.apps.googleusercontent.com&grant_type=urn%3Aietf%3Aparams%3Aoauth%3Agrant-type%3Atoken-exchange&requested_token_type=urn%3Aietf%3Aparams%3Aoauth%3Atoken-type%3Aaccess_token&scope=https%3A%2F%2Fwww.googleapis.com%2Fauth%2Fdevstorage.full_control&subject_token=street123&subject_token_type=urn%3Aietf%3Aparams%3Aoauth%3Atoken-type%3Ajwt"
+	baseCredsRequestBody                          = "audience=32555940559.apps.googleusercontent.com&grant_type=urn%3Aietf%3Aparams%3Aoauth%3Agrant-type%3Atoken-exchange&requested_token_type=urn%3Aietf%3Aparams%3Aoauth%3Atoken-type%3Aaccess_token&scope=https%3A%2F%2Fwww.googleapis.com%2Fauth%2Fdevstorage.full_control&subject_token=street123&subject_token_type=urn%3Aietf%3Aparams%3Aoauth%3Atoken-type%3Aid_token"
 	baseCredsResponseBody                         = `{"access_token":"Sample.Access.Token","issued_token_type":"urn:ietf:params:oauth:token-type:access_token","token_type":"Bearer","expires_in":3600,"scope":"https://www.googleapis.com/auth/cloud-platform"}`
-	workforcePoolRequestBodyWithClientId          = "audience=%2F%2Fiam.googleapis.com%2Flocations%2Feu%2FworkforcePools%2Fpool-id%2Fproviders%2Fprovider-id&grant_type=urn%3Aietf%3Aparams%3Aoauth%3Agrant-type%3Atoken-exchange&requested_token_type=urn%3Aietf%3Aparams%3Aoauth%3Atoken-type%3Aaccess_token&scope=https%3A%2F%2Fwww.googleapis.com%2Fauth%2Fdevstorage.full_control&subject_token=street123&subject_token_type=urn%3Aietf%3Aparams%3Aoauth%3Atoken-type%3Ajwt"
-	workforcePoolRequestBodyWithoutClientId       = "audience=%2F%2Fiam.googleapis.com%2Flocations%2Feu%2FworkforcePools%2Fpool-id%2Fproviders%2Fprovider-id&grant_type=urn%3Aietf%3Aparams%3Aoauth%3Agrant-type%3Atoken-exchange&options=%7B%22userProject%22%3A%22myProject%22%7D&requested_token_type=urn%3Aietf%3Aparams%3Aoauth%3Atoken-type%3Aaccess_token&scope=https%3A%2F%2Fwww.googleapis.com%2Fauth%2Fdevstorage.full_control&subject_token=street123&subject_token_type=urn%3Aietf%3Aparams%3Aoauth%3Atoken-type%3Ajwt"
+	workforcePoolRequestBodyWithClientId          = "audience=%2F%2Fiam.googleapis.com%2Flocations%2Feu%2FworkforcePools%2Fpool-id%2Fproviders%2Fprovider-id&grant_type=urn%3Aietf%3Aparams%3Aoauth%3Agrant-type%3Atoken-exchange&requested_token_type=urn%3Aietf%3Aparams%3Aoauth%3Atoken-type%3Aaccess_token&scope=https%3A%2F%2Fwww.googleapis.com%2Fauth%2Fdevstorage.full_control&subject_token=street123&subject_token_type=urn%3Aietf%3Aparams%3Aoauth%3Atoken-type%3Aid_token"
+	workforcePoolRequestBodyWithoutClientId       = "audience=%2F%2Fiam.googleapis.com%2Flocations%2Feu%2FworkforcePools%2Fpool-id%2Fproviders%2Fprovider-id&grant_type=urn%3Aietf%3Aparams%3Aoauth%3Agrant-type%3Atoken-exchange&options=%7B%22userProject%22%3A%22myProject%22%7D&requested_token_type=urn%3Aietf%3Aparams%3Aoauth%3Atoken-type%3Aaccess_token&scope=https%3A%2F%2Fwww.googleapis.com%2Fauth%2Fdevstorage.full_control&subject_token=street123&subject_token_type=urn%3Aietf%3Aparams%3Aoauth%3Atoken-type%3Aid_token"
 	correctAT                                     = "Sample.Access.Token"
 	expiry                                  int64 = 234852
 )
@@ -110,8 +110,7 @@ func validateToken(t *testing.T, tok *oauth2.Token) {
 func TestToken(t *testing.T) {
 	config := Config{
 		Audience:         "32555940559.apps.googleusercontent.com",
-		SubjectTokenType: "urn:ietf:params:oauth:token-type:jwt",
-		TokenInfoURL:     "http://localhost:8080/v1/tokeninfo",
+		SubjectTokenType: "urn:ietf:params:oauth:token-type:id_token",
 		ClientSecret:     "notsosecret",
 		ClientID:         "rbrgnognrhongo3bi4gb9ghg9g",
 		CredentialSource: testBaseCredSource,
@@ -137,8 +136,7 @@ func TestToken(t *testing.T) {
 func TestWorkforcePoolTokenWithClientID(t *testing.T) {
 	config := Config{
 		Audience:                 "//iam.googleapis.com/locations/eu/workforcePools/pool-id/providers/provider-id",
-		SubjectTokenType:         "urn:ietf:params:oauth:token-type:jwt",
-		TokenInfoURL:             "http://localhost:8080/v1/tokeninfo",
+		SubjectTokenType:         "urn:ietf:params:oauth:token-type:id_token",
 		ClientSecret:             "notsosecret",
 		ClientID:                 "rbrgnognrhongo3bi4gb9ghg9g",
 		CredentialSource:         testBaseCredSource,
@@ -165,8 +163,7 @@ func TestWorkforcePoolTokenWithClientID(t *testing.T) {
 func TestWorkforcePoolTokenWithoutClientID(t *testing.T) {
 	config := Config{
 		Audience:                 "//iam.googleapis.com/locations/eu/workforcePools/pool-id/providers/provider-id",
-		SubjectTokenType:         "urn:ietf:params:oauth:token-type:jwt",
-		TokenInfoURL:             "http://localhost:8080/v1/tokeninfo",
+		SubjectTokenType:         "urn:ietf:params:oauth:token-type:id_token",
 		ClientSecret:             "notsosecret",
 		CredentialSource:         testBaseCredSource,
 		Scopes:                   []string{"https://www.googleapis.com/auth/devstorage.full_control"},
@@ -192,8 +189,7 @@ func TestWorkforcePoolTokenWithoutClientID(t *testing.T) {
 func TestNonworkforceWithWorkforcePoolUserProject(t *testing.T) {
 	config := Config{
 		Audience:                 "32555940559.apps.googleusercontent.com",
-		SubjectTokenType:         "urn:ietf:params:oauth:token-type:jwt",
-		TokenInfoURL:             "http://localhost:8080/v1/tokeninfo",
+		SubjectTokenType:         "urn:ietf:params:oauth:token-type:id_token",
 		TokenURL:                 "https://sts.googleapis.com",
 		ClientSecret:             "notsosecret",
 		ClientID:                 "rbrgnognrhongo3bi4gb9ghg9g",


### PR DESCRIPTION
Workforce pools (external account credentials for non-Google users) are
organization-level resources which means that issued workforce pool tokens
will not have any client project ID on token exchange as currently designed.

"To use a Google API, the client must identify the application to the server.
If the API requires authentication, the client must also identify the principal
running the application."

The application here is the client project. The token will identify the user
principal but not the application. This will result in APIs rejecting requests
authenticated with these tokens.

Note that passing a x-goog-user-project override header on API request is
still not sufficient. The token is still expected to have a client project.

As a result, we have extended the spec to support an additional
workforce_pool_user_project for these credentials (workforce pools) which will
be passed when exchanging an external token for a Google Access token. After the
exchange, the issued access token will use the supplied project as the client
project. The underlying principal must still have serviceusage.services.use
IAM permission to use the project for billing/quota.

This field is not needed for flows with basic client authentication (e.g. client
ID is supplied). The client ID is sufficient to determine the client project and
any additionally supplied workforce_pool_user_project value will be ignored.

Note that this feature is not usable yet publicly.