### PR TITLE
Add HTTP client context message to `TokenSource`

### DIFF
--- a/clientcredentials/clientcredentials.go
+++ b/clientcredentials/clientcredentials.go
@@ -71,6 +71,9 @@ func (c *Config) Client(ctx context.Context) *http.Client {
 // automatically refreshing it as necessary using the provided context and the
 // client ID and client secret.
 //
+// The provided context optionally controls which HTTP client
+// is returned. See the oauth2.HTTPClient variable.
+//
 // Most users will use Config.Client instead.
 func (c *Config) TokenSource(ctx context.Context) oauth2.TokenSource {
 	source := &tokenSource{


### PR DESCRIPTION
While the other two methods of obtaining a token in the `clientcredentials` package, `Client` and `Token`, have the following message:

```
The provided context optionally controls which HTTP client is returned. See the oauth2.HTTPClient variable.
```

the third, `TokenSource`, does not, implying that the context can not control the HTTP client that is returned. This isn't true though, as `Token` uses `TokenSource` (https://cs.opensource.google/go/x/oauth2/+/2bc19b11:clientcredentials/clientcredentials.go;l=55-58;drc=80673b4a4bfc6c2c58a0b44cf9106913fe293994). So, we should have the same message for `TokenSource`.