### PR TITLE
Add DeviceAuthURL to Endpoint struct

### DIFF
--- a/oauth2.go
+++ b/oauth2.go
@@ -70,8 +70,9 @@ type TokenSource interface {
 // Endpoint represents an OAuth 2.0 provider's authorization and token
 // endpoint URLs.
 type Endpoint struct {
-	AuthURL  string
-	TokenURL string
+	AuthURL       string
+	TokenURL      string
+	DeviceAuthURL string
 
 	// AuthStyle optionally specifies how the endpoint wants the
 	// client ID & client secret sent. The zero value means to


### PR DESCRIPTION
go-oidc uses Endpoint to get the list of known endpoints available.
Adding this here will enable us to populate the device authorization
URL so that it doesn't need to be constructed by the library consumer.