### PR TITLE
add audience parameter for PasswordCredentialsToken

### DIFF
--- a/oauth2.go
+++ b/oauth2.go
@@ -39,6 +39,10 @@ func RegisterBrokenAuthHeaderProvider(tokenURL string) {}
 // For the client credentials 2-legged OAuth2 flow, see the clientcredentials
 // package (https://golang.org/x/oauth2/clientcredentials).
 type Config struct {
+	// Audience optionally specifies the intended audience of the
+	// request.
+	Audience string
+
 	// ClientID is the application's ID.
 	ClientID string
 
@@ -195,6 +199,9 @@ func (c *Config) PasswordCredentialsToken(ctx context.Context, username, passwor
 	if len(c.Scopes) > 0 {
 		v.Set("scope", strings.Join(c.Scopes, " "))
 	}
+	if c.Audience != "" {
+		v.Set("audience", c.Audience)
+	}
 	return retrieveToken(ctx, c, v)
 }
 
@@ -271,7 +278,6 @@ func (tf *tokenRefresher) Token() (*Token, error) {
 		"grant_type":    {"refresh_token"},
 		"refresh_token": {tf.refreshToken},
 	})
-
 	if err != nil {
 		return nil, err
 	}

--- a/oauth2_test.go
+++ b/oauth2_test.go
@@ -29,6 +29,7 @@ func (t *mockTransport) RoundTrip(req *http.Request) (resp *http.Response, err e
 
 func newConf(url string) *Config {
 	return &Config{
+		Audience:     "AUDIENCE",
 		ClientID:     "CLIENT_ID",
 		ClientSecret: "CLIENT_SECRET",
 		RedirectURL:  "REDIRECT_URL",
@@ -400,7 +401,7 @@ func TestPasswordCredentialsTokenRequest(t *testing.T) {
 		if err != nil {
 			t.Errorf("Failed reading request body: %s.", err)
 		}
-		expected = "grant_type=password&password=password1&scope=scope1+scope2&username=user1"
+		expected = "audience=AUDIENCE&grant_type=password&password=password1&scope=scope1+scope2&username=user1"
 		if string(body) != expected {
 			t.Errorf("res.Body = %q; want %q", string(body), expected)
 		}


### PR DESCRIPTION
Add possibility to add audience in `oauth2.Config` to use in PasswordCredentialsToken.
We need to add audience parameter in the request in order to get the token in JWT format, this is required by Auth0.