### PR TITLE
Correct content type for token if text/html

### DIFF
--- a/internal/token.go
+++ b/internal/token.go
@@ -248,7 +248,7 @@ func doTokenRoundTrip(ctx context.Context, req *http.Request) (*Token, error) {
 	var token *Token
 	content, _, _ := mime.ParseMediaType(r.Header.Get("Content-Type"))
 	switch content {
-	case "application/x-www-form-urlencoded", "text/plain":
+	case "application/x-www-form-urlencoded", "text/plain", "text/html":
 		vals, err := url.ParseQuery(string(body))
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
Problem with Deezer OAuth for getting the access token.
The content type of Deezer is "text/html".