### PR TITLE
endpoints: add Pinterest endpoints

### DIFF
--- a/endpoints/endpoints.go
+++ b/endpoints/endpoints.go
@@ -155,6 +155,12 @@ var PayPalSandbox = oauth2.Endpoint{
 	TokenURL: "https://api.sandbox.paypal.com/v1/identity/openidconnect/tokenservice",
 }
 
+// Pinterest is the endpoint for Pinterest.
+var Pinterest = oauth2.Endpoint{
+	AuthURL:  "https://www.pinterest.com/oauth",
+	TokenURL: "https://api.pinterest.com/v5/oauth/token",
+}
+
 // Slack is the endpoint for Slack.
 var Slack = oauth2.Endpoint{
 	AuthURL:  "https://slack.com/oauth/authorize",


### PR DESCRIPTION
Pinterest offers a [number of products](https://developers.pinterest.com/) to allow you to create buttons or widgets for your website or your application, show metadata on a pin, and so on.

Refer: https://developers.pinterest.com/docs/api/v5/