### PR TITLE
add Azure AD B2C endpoints

### DIFF
--- a/endpoints/endpoints.go
+++ b/endpoints/endpoints.go
@@ -230,6 +230,18 @@ func AzureAD(tenant string) oauth2.Endpoint {
 	}
 }
 
+// AzureADB2CEndpoint returns a new oauth2.Endpoint for the given tenant and policy at Azure Active Directory B2C.
+// policy is the Azure B2C User flow name Example: `B2C_1_SignUpSignIn`.
+// For more information see:
+// https://docs.microsoft.com/en-us/azure/active-directory-b2c/tokens-overview#endpoints
+
+func AzureADB2CEndpoint(tenant string, policy string) oauth2.Endpoint {
+	return oauth2.Endpoint{
+		AuthURL:  "https://" + tenant + ".b2clogin.com/" + tenant + ".onmicrosoft.com/" + policy + "/oauth2/v2.0/authorize",
+		TokenURL: "https://" + tenant + ".b2clogin.com/" + tenant + ".onmicrosoft.com/" + policy + "/oauth2/v2.0/token",
+	}
+}
+
 // HipChatServer returns a new oauth2.Endpoint for a HipChat Server instance
 // running on the given domain or host.
 func HipChatServer(host string) oauth2.Endpoint {

--- a/microsoft/microsoft.go
+++ b/microsoft/microsoft.go
@@ -29,3 +29,16 @@ func AzureADEndpoint(tenant string) oauth2.Endpoint {
 		TokenURL: "https://login.microsoftonline.com/" + tenant + "/oauth2/v2.0/token",
 	}
 }
+
+// AzureADB2CEndpoint returns a new oauth2.Endpoint for the given tenant and policy at Azure Active Directory B2C.
+// policy is the Azure B2C User flow name Example: `B2C_1_SignUpSignIn`.
+// For more information see:
+// https://docs.microsoft.com/en-us/azure/active-directory-b2c/tokens-overview#endpoints
+
+func AzureADB2CEndpoint(tenant string, policy string) oauth2.Endpoint {
+	return oauth2.Endpoint{
+		AuthURL:  "https://" + tenant + ".b2clogin.com/" + tenant + ".onmicrosoft.com/" + policy + "/oauth2/v2.0/authorize",
+		TokenURL: "https://" + tenant + ".b2clogin.com/" + tenant + ".onmicrosoft.com/" + policy + "/oauth2/v2.0/token",
+	}
+}
+


### PR DESCRIPTION
It is very common to mix up Azure AD and Azure B2C. Since endpoints are not the same, I implemented a function to get Azure AD B2C endpoints according to the documentation below.

https://docs.microsoft.com/en-us/azure/active-directory-b2c/tokens-overview#endpoints