### PR TITLE
clarify error when neither AccessToken nor RefreshToken is set

### DIFF
--- a/oauth2.go
+++ b/oauth2.go
@@ -298,7 +298,7 @@ type reuseTokenSource struct {
 func (s *reuseTokenSource) Token() (*Token, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	if s.t.AccessToken == "" && s.t.RefreshToken == "" {
+	if s.t != nil && s.t.AccessToken == "" && s.t.RefreshToken == "" {
 		return nil, errors.New("oauth2: Neither AccessToken (json: access_token) nor RefreshToken (json: refresh_token) is set")
 	}
 	if s.t.Valid() {

--- a/oauth2.go
+++ b/oauth2.go
@@ -298,6 +298,9 @@ type reuseTokenSource struct {
 func (s *reuseTokenSource) Token() (*Token, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
+	if s.t.AccessToken == "" && s.t.RefreshToken == "" {
+		return nil, errors.New("oauth2: Neither AccessToken (json: access_token) nor RefreshToken (json: refresh_token) is set")
+	}
 	if s.t.Valid() {
 		return s.t, nil
 	}


### PR DESCRIPTION
Right now, if all tokens are empty, the caller gets the following error:

`oauth2: token expired and refresh token is not set`

This is slightly misleading, as the token is not expired but it's entirely empty / missing.

this PR changes this to:

oauth2: Neither AccessToken (json: access_token) nor RefreshToken (json: refresh_token) is set