### PR TITLE
google/google: update documentation for workload identity federation

### DIFF
--- a/google/doc.go
+++ b/google/doc.go
@@ -40,9 +40,10 @@
 //	Microsoft Azure: https://cloud.google.com/iam/docs/access-resources-azure
 //	OIDC identity provider: https://cloud.google.com/iam/docs/access-resources-oidc
 //
-// For OIDC providers, the library can retrieve OIDC tokens either from a
-// local file location (file-sourced credentials) or from a local server
-// (URL-sourced credentials).
+// For OIDC and SAML providers, the library can retrieve tokens in three ways:
+// from a local file location (file-sourced credentials), from a server
+// (URL-sourced credentials), or from a local executable (executable-sourced
+// credentials).
 // For file-sourced credentials, a background process needs to be continuously
 // refreshing the file location with a new OIDC token prior to expiration.
 // For tokens with one hour lifetimes, the token needs to be updated in the file
@@ -50,6 +51,11 @@
 // For URL-sourced credentials, a local server needs to host a GET endpoint to
 // return the OIDC token. The response can be in plain text or JSON.
 // Additional required request headers can also be specified.
+// For executable-sourced credentials, an application needs to be available to
+// output the OIDC token and other information in a JSON format.
+// For more information on how these work (and how to implement
+// executable-sourced credentials), please check out:
+// https://cloud.google.com/iam/docs/using-workload-identity-federation#oidc
 //
 // # Credentials
 //


### PR DESCRIPTION
Including information on executable-sourced credentials