### PR TITLE
google/internal/externalaccount: Added check for aws region and security credential environment variables before aws metadata call

### DIFF
--- a/google/internal/externalaccount/aws.go
+++ b/google/internal/externalaccount/aws.go
@@ -62,11 +62,13 @@ const (
 	// The AWS authorization header name for the auto-generated date.
 	awsDateHeader = "x-amz-date"
 
+	// Supported AWS configuration environment variables.
 	awsAccessKeyId     = "AWS_ACCESS_KEY_ID"
 	awsDefaultRegion   = "AWS_DEFAULT_REGION"
 	awsRegion          = "AWS_REGION"
 	awsSecretAccessKey = "AWS_SECRET_ACCESS_KEY"
 	awsSessionToken    = "AWS_SESSION_TOKEN"
+
 	awsTimeFormatLong  = "20060102T150405Z"
 	awsTimeFormatShort = "20060102"
 )

--- a/google/internal/externalaccount/aws.go
+++ b/google/internal/externalaccount/aws.go
@@ -62,6 +62,11 @@ const (
 	// The AWS authorization header name for the auto-generated date.
 	awsDateHeader = "x-amz-date"
 
+	awsAccessKeyId     = "AWS_ACCESS_KEY_ID"
+	awsDefaultRegion   = "AWS_DEFAULT_REGION"
+	awsRegion          = "AWS_REGION"
+	awsSecretAccessKey = "AWS_SECRET_ACCESS_KEY"
+	awsSessionToken    = "AWS_SESSION_TOKEN"
 	awsTimeFormatLong  = "20060102T150405Z"
 	awsTimeFormatShort = "20060102"
 )
@@ -317,16 +322,33 @@ func (cs awsCredentialSource) doRequest(req *http.Request) (*http.Response, erro
 	return cs.client.Do(req.WithContext(cs.ctx))
 }
 
+func canRetrieveRegionFromEnvironment() bool {
+	// The AWS region can be provided through AWS_REGION or AWS_DEFAULT_REGION. Only one is
+	// required.
+	return getenv(awsRegion) != "" || getenv(awsDefaultRegion) != ""
+}
+
+func canRetrieveSecurityCredentialFromEnvironment() bool {
+	// Check if both AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY are available.
+	return getenv(awsAccessKeyId) != "" && getenv(awsSecretAccessKey) != ""
+}
+
+func shouldUseMetadataServer() bool {
+	return !canRetrieveRegionFromEnvironment() || !canRetrieveSecurityCredentialFromEnvironment()
+}
+
 func (cs awsCredentialSource) subjectToken() (string, error) {
 	if cs.requestSigner == nil {
-		awsSessionToken, err := cs.getAWSSessionToken()
-		if err != nil {
-			return "", err
-		}
-
 		headers := make(map[string]string)
-		if awsSessionToken != "" {
-			headers[awsIMDSv2SessionTokenHeader] = awsSessionToken
+		if shouldUseMetadataServer() {
+			awsSessionToken, err := cs.getAWSSessionToken()
+			if err != nil {
+				return "", err
+			}
+
+			if awsSessionToken != "" {
+				headers[awsIMDSv2SessionTokenHeader] = awsSessionToken
+			}
 		}
 
 		awsSecurityCredentials, err := cs.getSecurityCredentials(headers)
@@ -432,11 +454,11 @@ func (cs *awsCredentialSource) getAWSSessionToken() (string, error) {
 }
 
 func (cs *awsCredentialSource) getRegion(headers map[string]string) (string, error) {
-	if envAwsRegion := getenv("AWS_REGION"); envAwsRegion != "" {
-		return envAwsRegion, nil
-	}
-	if envAwsRegion := getenv("AWS_DEFAULT_REGION"); envAwsRegion != "" {
-		return envAwsRegion, nil
+	if canRetrieveRegionFromEnvironment() {
+		if envAwsRegion := getenv(awsRegion); envAwsRegion != "" {
+			return envAwsRegion, nil
+		}
+		return getenv("AWS_DEFAULT_REGION"), nil
 	}
 
 	if cs.RegionURL == "" {
@@ -477,14 +499,12 @@ func (cs *awsCredentialSource) getRegion(headers map[string]string) (string, err
 }
 
 func (cs *awsCredentialSource) getSecurityCredentials(headers map[string]string) (result awsSecurityCredentials, err error) {
-	if accessKeyID := getenv("AWS_ACCESS_KEY_ID"); accessKeyID != "" {
-		if secretAccessKey := getenv("AWS_SECRET_ACCESS_KEY"); secretAccessKey != "" {
-			return awsSecurityCredentials{
-				AccessKeyID:     accessKeyID,
-				SecretAccessKey: secretAccessKey,
-				SecurityToken:   getenv("AWS_SESSION_TOKEN"),
-			}, nil
-		}
+	if canRetrieveSecurityCredentialFromEnvironment() {
+		return awsSecurityCredentials{
+			AccessKeyID:     getenv(awsAccessKeyId),
+			SecretAccessKey: getenv(awsSecretAccessKey),
+			SecurityToken:   getenv(awsSessionToken),
+		}, nil
 	}
 
 	roleName, err := cs.getMetadataRoleName(headers)


### PR DESCRIPTION
Adds check for aws values in environment variables before the metadata server is called to prevent unnecessary off box calls. See https://github.com/googleapis/google-auth-library-java/pull/1100 for same change in java library.