### PR TITLE
endpoints: add Vault Vision endpoints

### DIFF
--- a/endpoints/endpoints.go
+++ b/endpoints/endpoints.go
@@ -254,3 +254,19 @@ func AWSCognito(domain string) oauth2.Endpoint {
 		TokenURL: domain + "/oauth2/token",
 	}
 }
+
+// VaultVision returns a new oauth2.Endpoint for the supplied Vault Vision
+// tenant domain.
+//
+// Example domain: https://testing.vvkey.io
+// Example custom domain: https://auth.vaultvision.com
+//
+// For more information see:
+// https://docs.vaultvision.com/getting_started.html
+func VaultVision(domain string) oauth2.Endpoint {
+	domain = strings.TrimRight(domain, "/")
+	return oauth2.Endpoint{
+		AuthURL:  domain + "/authorize",
+		TokenURL: domain + "/oauth/token",
+	}
+}

--- a/endpoints/endpoints_test.go
+++ b/endpoints/endpoints_test.go
@@ -41,3 +41,35 @@ func TestAWSCognitoEndpoint(t *testing.T) {
 		})
 	}
 }
+
+func TestVaultVisionEndpoint(t *testing.T) {
+
+	var endpointTests = []struct {
+		in  string
+		out oauth2.Endpoint
+	}{
+		{
+			in: "https://testing.vvkey.io",
+			out: oauth2.Endpoint{
+				AuthURL:  "https://testing.vvkey.io/authorize",
+				TokenURL: "https://testing.vvkey.io/oauth/token",
+			},
+		},
+		{
+			in: "https://auth.vaultvision.com",
+			out: oauth2.Endpoint{
+				AuthURL:  "https://auth.vaultvision.com/authorize",
+				TokenURL: "https://auth.vaultvision.com/oauth/token",
+			},
+		},
+	}
+
+	for _, tt := range endpointTests {
+		t.Run(tt.in, func(t *testing.T) {
+			endpoint := VaultVision(tt.in)
+			if endpoint != tt.out {
+				t.Errorf("got %q, want %q", endpoint, tt.out)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This adds a function for the multi-tenant authentication platform provided by Vault Vision. It is similar to the AWSCognito function and includes a basic unit test.