### PR TITLE
endpoints: remove duplicated URLs from legacy packages

### DIFF
--- a/amazon/amazon.go
+++ b/amazon/amazon.go
@@ -6,11 +6,8 @@
 package amazon
 
 import (
-	"golang.org/x/oauth2"
+	"golang.org/x/oauth2/endpoints"
 )
 
 // Endpoint is Amazon's OAuth 2.0 endpoint.
-var Endpoint = oauth2.Endpoint{
-	AuthURL:  "https://www.amazon.com/ap/oa",
-	TokenURL: "https://api.amazon.com/auth/o2/token",
-}
+var Endpoint = endpoints.Amazon

--- a/bitbucket/bitbucket.go
+++ b/bitbucket/bitbucket.go
@@ -6,11 +6,8 @@
 package bitbucket
 
 import (
-	"golang.org/x/oauth2"
+	"golang.org/x/oauth2/endpoints"
 )
 
 // Endpoint is Bitbucket's OAuth 2.0 endpoint.
-var Endpoint = oauth2.Endpoint{
-	AuthURL:  "https://bitbucket.org/site/oauth2/authorize",
-	TokenURL: "https://bitbucket.org/site/oauth2/access_token",
-}
+var Endpoint = endpoints.Bitbucket

--- a/cern/cern.go
+++ b/cern/cern.go
@@ -6,11 +6,8 @@
 package cern // import "golang.org/x/oauth2/cern"
 
 import (
-	"golang.org/x/oauth2"
+	"golang.org/x/oauth2/endpoints"
 )
 
 // Endpoint is CERN's OAuth 2.0 endpoint.
-var Endpoint = oauth2.Endpoint{
-	AuthURL:  "https://oauth.web.cern.ch/OAuth/Authorize",
-	TokenURL: "https://oauth.web.cern.ch/OAuth/Token",
-}
+var Endpoint = endpoints.Cern

--- a/endpoints/endpoints.go
+++ b/endpoints/endpoints.go
@@ -67,8 +67,9 @@ var GitLab = oauth2.Endpoint{
 
 // Google is the endpoint for Google.
 var Google = oauth2.Endpoint{
-	AuthURL:  "https://accounts.google.com/o/oauth2/auth",
-	TokenURL: "https://oauth2.googleapis.com/token",
+	AuthURL:   "https://accounts.google.com/o/oauth2/auth",
+	TokenURL:  "https://oauth2.googleapis.com/token",
+	AuthStyle: oauth2.AuthStyleInParams,
 }
 
 // Heroku is the endpoint for Heroku.
@@ -97,8 +98,9 @@ var KaKao = oauth2.Endpoint{
 
 // LinkedIn is the endpoint for LinkedIn.
 var LinkedIn = oauth2.Endpoint{
-	AuthURL:  "https://www.linkedin.com/oauth/v2/authorization",
-	TokenURL: "https://www.linkedin.com/oauth/v2/accessToken",
+	AuthURL:   "https://www.linkedin.com/oauth/v2/authorization",
+	TokenURL:  "https://www.linkedin.com/oauth/v2/accessToken",
+	AuthStyle: oauth2.AuthStyleInParams,
 }
 
 // Mailchimp is the endpoint for Mailchimp.

--- a/facebook/facebook.go
+++ b/facebook/facebook.go
@@ -6,11 +6,8 @@
 package facebook // import "golang.org/x/oauth2/facebook"
 
 import (
-	"golang.org/x/oauth2"
+	"golang.org/x/oauth2/endpoints"
 )
 
 // Endpoint is Facebook's OAuth 2.0 endpoint.
-var Endpoint = oauth2.Endpoint{
-	AuthURL:  "https://www.facebook.com/v3.2/dialog/oauth",
-	TokenURL: "https://graph.facebook.com/v3.2/oauth/access_token",
-}
+var Endpoint = endpoints.Facebook

--- a/fitbit/fitbit.go
+++ b/fitbit/fitbit.go
@@ -6,11 +6,8 @@
 package fitbit // import "golang.org/x/oauth2/fitbit"
 
 import (
-	"golang.org/x/oauth2"
+	"golang.org/x/oauth2/endpoints"
 )
 
 // Endpoint is the Fitbit API's OAuth 2.0 endpoint.
-var Endpoint = oauth2.Endpoint{
-	AuthURL:  "https://www.fitbit.com/oauth2/authorize",
-	TokenURL: "https://api.fitbit.com/oauth2/token",
-}
+var Endpoint = endpoints.Fitbit

--- a/foursquare/foursquare.go
+++ b/foursquare/foursquare.go
@@ -6,11 +6,8 @@
 package foursquare // import "golang.org/x/oauth2/foursquare"
 
 import (
-	"golang.org/x/oauth2"
+	"golang.org/x/oauth2/endpoints"
 )
 
 // Endpoint is Foursquare's OAuth 2.0 endpoint.
-var Endpoint = oauth2.Endpoint{
-	AuthURL:  "https://foursquare.com/oauth2/authorize",
-	TokenURL: "https://foursquare.com/oauth2/access_token",
-}
+var Endpoint = endpoints.Foursquare

--- a/github/github.go
+++ b/github/github.go
@@ -6,11 +6,8 @@
 package github // import "golang.org/x/oauth2/github"
 
 import (
-	"golang.org/x/oauth2"
+	"golang.org/x/oauth2/endpoints"
 )
 
 // Endpoint is Github's OAuth 2.0 endpoint.
-var Endpoint = oauth2.Endpoint{
-	AuthURL:  "https://github.com/login/oauth/authorize",
-	TokenURL: "https://github.com/login/oauth/access_token",
-}
+var Endpoint = endpoints.GitHub

--- a/gitlab/gitlab.go
+++ b/gitlab/gitlab.go
@@ -6,11 +6,8 @@
 package gitlab // import "golang.org/x/oauth2/gitlab"
 
 import (
-	"golang.org/x/oauth2"
+	"golang.org/x/oauth2/endpoints"
 )
 
 // Endpoint is GitLab's OAuth 2.0 endpoint.
-var Endpoint = oauth2.Endpoint{
-	AuthURL:  "https://gitlab.com/oauth/authorize",
-	TokenURL: "https://gitlab.com/oauth/token",
-}
+var Endpoint = endpoints.GitLab

--- a/google/google.go
+++ b/google/google.go
@@ -15,16 +15,13 @@ import (
 
 	"cloud.google.com/go/compute/metadata"
 	"golang.org/x/oauth2"
+	"golang.org/x/oauth2/endpoints"
 	"golang.org/x/oauth2/google/internal/externalaccount"
 	"golang.org/x/oauth2/jwt"
 )
 
 // Endpoint is Google's OAuth 2.0 default endpoint.
-var Endpoint = oauth2.Endpoint{
-	AuthURL:   "https://accounts.google.com/o/oauth2/auth",
-	TokenURL:  "https://oauth2.googleapis.com/token",
-	AuthStyle: oauth2.AuthStyleInParams,
-}
+var Endpoint = endpoints.Google
 
 // JWTTokenURL is Google's OAuth 2.0 token URL to use with the JWT flow.
 const JWTTokenURL = "https://oauth2.googleapis.com/token"

--- a/heroku/heroku.go
+++ b/heroku/heroku.go
@@ -6,11 +6,8 @@
 package heroku // import "golang.org/x/oauth2/heroku"
 
 import (
-	"golang.org/x/oauth2"
+	"golang.org/x/oauth2/endpoints"
 )
 
 // Endpoint is Heroku's OAuth 2.0 endpoint.
-var Endpoint = oauth2.Endpoint{
-	AuthURL:  "https://id.heroku.com/oauth/authorize",
-	TokenURL: "https://id.heroku.com/oauth/token",
-}
+var Endpoint = endpoints.Heroku

--- a/hipchat/hipchat.go
+++ b/hipchat/hipchat.go
@@ -11,21 +11,16 @@ import (
 
 	"golang.org/x/oauth2"
 	"golang.org/x/oauth2/clientcredentials"
+	"golang.org/x/oauth2/endpoints"
 )
 
 // Endpoint is HipChat's OAuth 2.0 endpoint.
-var Endpoint = oauth2.Endpoint{
-	AuthURL:  "https://www.hipchat.com/users/authorize",
-	TokenURL: "https://api.hipchat.com/v2/oauth/token",
-}
+var Endpoint = endpoints.HipChat
 
 // ServerEndpoint returns a new oauth2.Endpoint for a HipChat Server instance
 // running on the given domain or host.
 func ServerEndpoint(host string) oauth2.Endpoint {
-	return oauth2.Endpoint{
-		AuthURL:  "https://" + host + "/users/authorize",
-		TokenURL: "https://" + host + "/v2/oauth/token",
-	}
+	return endpoints.HipChatServer(host)
 }
 
 // ClientCredentialsConfigFromCaps generates a Config from a HipChat API

--- a/instagram/instagram.go
+++ b/instagram/instagram.go
@@ -6,11 +6,8 @@
 package instagram // import "golang.org/x/oauth2/instagram"
 
 import (
-	"golang.org/x/oauth2"
+	"golang.org/x/oauth2/endpoints"
 )
 
 // Endpoint is Instagram's OAuth 2.0 endpoint.
-var Endpoint = oauth2.Endpoint{
-	AuthURL:  "https://api.instagram.com/oauth/authorize",
-	TokenURL: "https://api.instagram.com/oauth/access_token",
-}
+var Endpoint = endpoints.Instagram

--- a/kakao/kakao.go
+++ b/kakao/kakao.go
@@ -6,11 +6,8 @@
 package kakao // import "golang.org/x/oauth2/kakao"
 
 import (
-	"golang.org/x/oauth2"
+	"golang.org/x/oauth2/endpoints"
 )
 
 // Endpoint is Kakao's OAuth 2.0 endpoint.
-var Endpoint = oauth2.Endpoint{
-	AuthURL:  "https://kauth.kakao.com/oauth/authorize",
-	TokenURL: "https://kauth.kakao.com/oauth/token",
-}
+var Endpoint = endpoints.KaKao

--- a/linkedin/linkedin.go
+++ b/linkedin/linkedin.go
@@ -6,12 +6,8 @@
 package linkedin // import "golang.org/x/oauth2/linkedin"
 
 import (
-	"golang.org/x/oauth2"
+	"golang.org/x/oauth2/endpoints"
 )
 
 // Endpoint is LinkedIn's OAuth 2.0 endpoint.
-var Endpoint = oauth2.Endpoint{
-	AuthURL:   "https://www.linkedin.com/oauth/v2/authorization",
-	TokenURL:  "https://www.linkedin.com/oauth/v2/accessToken",
-	AuthStyle: oauth2.AuthStyleInParams,
-}
+var Endpoint = endpoints.LinkedIn

--- a/mailchimp/mailchimp.go
+++ b/mailchimp/mailchimp.go
@@ -6,12 +6,9 @@
 package mailchimp // import "golang.org/x/oauth2/mailchimp"
 
 import (
-	"golang.org/x/oauth2"
+	"golang.org/x/oauth2/endpoints"
 )
 
 // Endpoint is MailChimp's OAuth 2.0 endpoint.
 // See http://developer.mailchimp.com/documentation/mailchimp/guides/how-to-use-oauth2/
-var Endpoint = oauth2.Endpoint{
-	AuthURL:  "https://login.mailchimp.com/oauth2/authorize",
-	TokenURL: "https://login.mailchimp.com/oauth2/token",
-}
+var Endpoint = endpoints.Mailchimp

--- a/mailru/mailru.go
+++ b/mailru/mailru.go
@@ -6,11 +6,8 @@
 package mailru // import "golang.org/x/oauth2/mailru"
 
 import (
-	"golang.org/x/oauth2"
+	"golang.org/x/oauth2/endpoints"
 )
 
 // Endpoint is Mail.Ru's OAuth 2.0 endpoint.
-var Endpoint = oauth2.Endpoint{
-	AuthURL:  "https://o2.mail.ru/login",
-	TokenURL: "https://o2.mail.ru/token",
-}
+var Endpoint = endpoints.Mailru

--- a/mediamath/mediamath.go
+++ b/mediamath/mediamath.go
@@ -6,17 +6,11 @@
 package mediamath // import "golang.org/x/oauth2/mediamath"
 
 import (
-	"golang.org/x/oauth2"
+	"golang.org/x/oauth2/endpoints"
 )
 
 // Endpoint is MediaMath's OAuth 2.0 endpoint for production.
-var Endpoint = oauth2.Endpoint{
-	AuthURL:  "https://api.mediamath.com/oauth2/v1.0/authorize",
-	TokenURL: "https://api.mediamath.com/oauth2/v1.0/token",
-}
+var Endpoint = endpoints.MediaMath
 
 // SandboxEndpoint is MediaMath's OAuth 2.0 endpoint for sandbox.
-var SandboxEndpoint = oauth2.Endpoint{
-	AuthURL:  "https://t1sandbox.mediamath.com/oauth2/v1.0/authorize",
-	TokenURL: "https://t1sandbox.mediamath.com/oauth2/v1.0/token",
-}
+var SandboxEndpoint = endpoints.MediaMathSandbox

--- a/microsoft/microsoft.go
+++ b/microsoft/microsoft.go
@@ -7,13 +7,11 @@ package microsoft // import "golang.org/x/oauth2/microsoft"
 
 import (
 	"golang.org/x/oauth2"
+	"golang.org/x/oauth2/endpoints"
 )
 
 // LiveConnectEndpoint is Windows's Live ID OAuth 2.0 endpoint.
-var LiveConnectEndpoint = oauth2.Endpoint{
-	AuthURL:  "https://login.live.com/oauth20_authorize.srf",
-	TokenURL: "https://login.live.com/oauth20_token.srf",
-}
+var LiveConnectEndpoint = endpoints.Microsoft
 
 // AzureADEndpoint returns a new oauth2.Endpoint for the given tenant at Azure Active Directory.
 // If tenant is empty, it uses the tenant called `common`.
@@ -21,11 +19,5 @@ var LiveConnectEndpoint = oauth2.Endpoint{
 // For more information see:
 // https://docs.microsoft.com/en-us/azure/active-directory/develop/active-directory-v2-protocols#endpoints
 func AzureADEndpoint(tenant string) oauth2.Endpoint {
-	if tenant == "" {
-		tenant = "common"
-	}
-	return oauth2.Endpoint{
-		AuthURL:  "https://login.microsoftonline.com/" + tenant + "/oauth2/v2.0/authorize",
-		TokenURL: "https://login.microsoftonline.com/" + tenant + "/oauth2/v2.0/token",
-	}
+	return endpoints.AzureAD(tenant)
 }

--- a/nokiahealth/nokiahealth.go
+++ b/nokiahealth/nokiahealth.go
@@ -6,11 +6,8 @@
 package nokiahealth
 
 import (
-	"golang.org/x/oauth2"
+	"golang.org/x/oauth2/endpoints"
 )
 
 // Endpoint is Nokia Health Mate's OAuth 2.0 endpoint.
-var Endpoint = oauth2.Endpoint{
-	AuthURL:  "https://account.health.nokia.com/oauth2_user/authorize2",
-	TokenURL: "https://account.health.nokia.com/oauth2/token",
-}
+var Endpoint = endpoints.NokiaHealth

--- a/odnoklassniki/odnoklassniki.go
+++ b/odnoklassniki/odnoklassniki.go
@@ -6,11 +6,8 @@
 package odnoklassniki // import "golang.org/x/oauth2/odnoklassniki"
 
 import (
-	"golang.org/x/oauth2"
+	"golang.org/x/oauth2/endpoints"
 )
 
 // Endpoint is Odnoklassniki's OAuth 2.0 endpoint.
-var Endpoint = oauth2.Endpoint{
-	AuthURL:  "https://www.odnoklassniki.ru/oauth/authorize",
-	TokenURL: "https://api.odnoklassniki.ru/oauth/token.do",
-}
+var Endpoint = endpoints.Odnoklassniki

--- a/paypal/paypal.go
+++ b/paypal/paypal.go
@@ -6,17 +6,11 @@
 package paypal // import "golang.org/x/oauth2/paypal"
 
 import (
-	"golang.org/x/oauth2"
+	"golang.org/x/oauth2/endpoints"
 )
 
 // Endpoint is PayPal's OAuth 2.0 endpoint in live (production) environment.
-var Endpoint = oauth2.Endpoint{
-	AuthURL:  "https://www.paypal.com/webapps/auth/protocol/openidconnect/v1/authorize",
-	TokenURL: "https://api.paypal.com/v1/identity/openidconnect/tokenservice",
-}
+var Endpoint = endpoints.PayPal
 
 // SandboxEndpoint is PayPal's OAuth 2.0 endpoint in sandbox (testing) environment.
-var SandboxEndpoint = oauth2.Endpoint{
-	AuthURL:  "https://www.sandbox.paypal.com/webapps/auth/protocol/openidconnect/v1/authorize",
-	TokenURL: "https://api.sandbox.paypal.com/v1/identity/openidconnect/tokenservice",
-}
+var SandboxEndpoint = endpoints.PayPalSandbox

--- a/slack/slack.go
+++ b/slack/slack.go
@@ -6,11 +6,8 @@
 package slack // import "golang.org/x/oauth2/slack"
 
 import (
-	"golang.org/x/oauth2"
+	"golang.org/x/oauth2/endpoints"
 )
 
 // Endpoint is Slack's OAuth 2.0 endpoint.
-var Endpoint = oauth2.Endpoint{
-	AuthURL:  "https://slack.com/oauth/authorize",
-	TokenURL: "https://slack.com/api/oauth.access",
-}
+var Endpoint = endpoints.Slack

--- a/spotify/spotify.go
+++ b/spotify/spotify.go
@@ -6,11 +6,8 @@
 package spotify // import "golang.org/x/oauth2/spotify"
 
 import (
-	"golang.org/x/oauth2"
+	"golang.org/x/oauth2/endpoints"
 )
 
 // Endpoint is Spotify's OAuth 2.0 endpoint.
-var Endpoint = oauth2.Endpoint{
-	AuthURL:  "https://accounts.spotify.com/authorize",
-	TokenURL: "https://accounts.spotify.com/api/token",
-}
+var Endpoint = endpoints.Spotify

--- a/stackoverflow/stackoverflow.go
+++ b/stackoverflow/stackoverflow.go
@@ -6,11 +6,8 @@
 package stackoverflow // import "golang.org/x/oauth2/stackoverflow"
 
 import (
-	"golang.org/x/oauth2"
+	"golang.org/x/oauth2/endpoints"
 )
 
 // Endpoint is Stack Overflow's OAuth 2.0 endpoint.
-var Endpoint = oauth2.Endpoint{
-	AuthURL:  "https://stackoverflow.com/oauth",
-	TokenURL: "https://stackoverflow.com/oauth/access_token",
-}
+var Endpoint = endpoints.StackOverflow

--- a/twitch/twitch.go
+++ b/twitch/twitch.go
@@ -6,14 +6,11 @@
 package twitch // import "golang.org/x/oauth2/twitch"
 
 import (
-	"golang.org/x/oauth2"
+	"golang.org/x/oauth2/endpoints"
 )
 
 // Endpoint is Twitch's OAuth 2.0 endpoint.
 //
 // For more information see:
 // https://dev.twitch.tv/docs/authentication
-var Endpoint = oauth2.Endpoint{
-	AuthURL:  "https://id.twitch.tv/oauth2/authorize",
-	TokenURL: "https://id.twitch.tv/oauth2/token",
-}
+var Endpoint = endpoints.Twitch

--- a/uber/uber.go
+++ b/uber/uber.go
@@ -6,11 +6,8 @@
 package uber // import "golang.org/x/oauth2/uber"
 
 import (
-	"golang.org/x/oauth2"
+	"golang.org/x/oauth2/endpoints"
 )
 
 // Endpoint is Uber's OAuth 2.0 endpoint.
-var Endpoint = oauth2.Endpoint{
-	AuthURL:  "https://login.uber.com/oauth/v2/authorize",
-	TokenURL: "https://login.uber.com/oauth/v2/token",
-}
+var Endpoint = endpoints.Uber

--- a/vk/vk.go
+++ b/vk/vk.go
@@ -6,11 +6,8 @@
 package vk // import "golang.org/x/oauth2/vk"
 
 import (
-	"golang.org/x/oauth2"
+	"golang.org/x/oauth2/endpoints"
 )
 
 // Endpoint is VK's OAuth 2.0 endpoint.
-var Endpoint = oauth2.Endpoint{
-	AuthURL:  "https://oauth.vk.com/authorize",
-	TokenURL: "https://oauth.vk.com/access_token",
-}
+var Endpoint = endpoints.Vk

--- a/yahoo/yahoo.go
+++ b/yahoo/yahoo.go
@@ -6,12 +6,9 @@
 package yahoo // import "golang.org/x/oauth2/yahoo"
 
 import (
-	"golang.org/x/oauth2"
+	"golang.org/x/oauth2/endpoints"
 )
 
 // Endpoint is Yahoo's OAuth 2.0 endpoint.
 // See https://developer.yahoo.com/oauth2/guide/
-var Endpoint = oauth2.Endpoint{
-	AuthURL:  "https://api.login.yahoo.com/oauth2/request_auth",
-	TokenURL: "https://api.login.yahoo.com/oauth2/get_token",
-}
+var Endpoint = endpoints.Yahoo

--- a/yandex/yandex.go
+++ b/yandex/yandex.go
@@ -6,11 +6,8 @@
 package yandex // import "golang.org/x/oauth2/yandex"
 
 import (
-	"golang.org/x/oauth2"
+	"golang.org/x/oauth2/endpoints"
 )
 
 // Endpoint is the Yandex OAuth 2.0 endpoint.
-var Endpoint = oauth2.Endpoint{
-	AuthURL:  "https://oauth.yandex.com/authorize",
-	TokenURL: "https://oauth.yandex.com/token",
-}
+var Endpoint = endpoints.Yandex


### PR DESCRIPTION
I noticed that the identical endpoint URLs are repeated in multiple packages, making them difficult to maintain.

This makes the legacy packages reference the ones defined in endpoints package in a backwards compatible manner.