### PR TITLE
oauth2: workaround misspelling of verification_uri

### DIFF
--- a/deviceauth.go
+++ b/deviceauth.go
@@ -58,6 +58,8 @@ func (c *DeviceAuthResponse) UnmarshalJSON(data []byte) error {
 	type Alias DeviceAuthResponse
 	aux := &struct {
 		ExpiresIn int64 `json:"expires_in"`
+		// workaround misspelling of verification_uri
+		VerificationURL string `json:"verification_url"`
 		*Alias
 	}{
 		Alias: (*Alias)(c),
@@ -67,6 +69,9 @@ func (c *DeviceAuthResponse) UnmarshalJSON(data []byte) error {
 	}
 	if aux.ExpiresIn != 0 {
 		c.Expiry = time.Now().UTC().Add(time.Second * time.Duration(aux.ExpiresIn))
+	}
+	if c.VerificationURI == "" {
+		c.VerificationURI = aux.VerificationURL
 	}
 	return nil
 }


### PR DESCRIPTION
Some servers misspell verification_uri as verification_url, contrary to spec RFC 8628

Example server https://issuetracker.google.com/issues/151238144

Fixes #666