### PR TITLE
golang/oauth2: added OnTokenRefresh callback method

### DIFF
--- a/google/doc.go
+++ b/google/doc.go
@@ -101,6 +101,8 @@
 // executable-sourced credentials), please check out:
 // https://cloud.google.com/iam/docs/workforce-obtaining-short-lived-credentials#generate_a_configuration_file_for_non-interactive_sign-in
 //
+// # Security considerations
+//
 // Note that this library does not perform any validation on the token_url, token_info_url,
 // or service_account_impersonation_url fields of the credential configuration.
 // It is not recommended to use a credential configuration that you did not generate with

--- a/oauth2.go
+++ b/oauth2.go
@@ -318,7 +318,7 @@ func (s *reuseTokenSource) Token() (*Token, error) {
 		return nil, err
 	}
 	t.expiryDelta = s.expiryDelta
-	if s.t.OnTokenRefresh != nil {
+	if s.t != nil && s.t.OnTokenRefresh != nil {
 		t.OnTokenRefresh = s.t.OnTokenRefresh
 		t.OnTokenRefresh(*t)
 	}

--- a/oauth2.go
+++ b/oauth2.go
@@ -318,11 +318,11 @@ func (s *reuseTokenSource) Token() (*Token, error) {
 		return nil, err
 	}
 	t.expiryDelta = s.expiryDelta
-	t.OnTokenRefresh = s.t.OnTokenRefresh
-	s.t = t
-	if t.OnTokenRefresh != nil {
+	if s.t.OnTokenRefresh != nil {
+		t.OnTokenRefresh = s.t.OnTokenRefresh
 		t.OnTokenRefresh(*t)
 	}
+	s.t = t
 	return t, nil
 }
 


### PR DESCRIPTION
This pr implements the most simple way of attaching a callback for token refreshes. Whenever the token gets refreshed by the client, this method will be called. This allows to get notified whenever the access token or refresh token expires and be able to store those new credentials inside a database for future requests.