### PR TITLE
golang/oauth2: add AuthCodeOption (can add extra params)

### DIFF
--- a/oauth2.go
+++ b/oauth2.go
@@ -195,7 +195,7 @@ func (c *Config) AuthCodeURL(state string, opts ...AuthCodeOption) string {
 // See https://tools.ietf.org/html/rfc6749#section-4.3 for more info.
 //
 // The provided context optionally controls which HTTP client is used. See the HTTPClient variable.
-func (c *Config) PasswordCredentialsToken(ctx context.Context, username, password string) (*Token, error) {
+func (c *Config) PasswordCredentialsToken(ctx context.Context, username, password string, opts ...AuthCodeOption) (*Token, error) {
 	v := url.Values{
 		"grant_type": {"password"},
 		"username":   {username},
@@ -203,6 +203,9 @@ func (c *Config) PasswordCredentialsToken(ctx context.Context, username, passwor
 	}
 	if len(c.Scopes) > 0 {
 		v.Set("scope", strings.Join(c.Scopes, " "))
+	}
+	for _, opt := range opts {
+		opt.setValue(v)
 	}
 	return retrieveToken(ctx, c, v)
 }

--- a/oauth2_test.go
+++ b/oauth2_test.go
@@ -425,7 +425,6 @@ func TestPasswordCredentialsTokenRequest(t *testing.T) {
 
 func TestPasswordCredentialsTokenRequest_AuthCodeOption(t *testing.T) {
 	testCases := map[string]struct {
-		ctx                   context.Context
 		username              string
 		password              string
 		authCodeOptions       []AuthCodeOption

--- a/oauth2_test.go
+++ b/oauth2_test.go
@@ -447,7 +447,7 @@ func TestPasswordCredentialsTokenRequest_AuthCodeOption(t *testing.T) {
 			wantAccessToken:       "90d64460d14870c08c81352a05dedd3465940a7c",
 			wantTokenType:         "bearer",
 		},
-		"foo:bar": {
+		"foo=bar": {
 			username:              "user1",
 			password:              "password1",
 			authCodeOptions:       []AuthCodeOption{SetAuthURLParam("foo", "bar")},
@@ -458,7 +458,7 @@ func TestPasswordCredentialsTokenRequest_AuthCodeOption(t *testing.T) {
 			wantAccessToken:       "90d64460d14870c08c81352a05dedd3465940a7c",
 			wantTokenType:         "bearer",
 		},
-		"zoo:baz": {
+		"zoo=baz": {
 			username:              "user1",
 			password:              "password1",
 			authCodeOptions:       []AuthCodeOption{SetAuthURLParam("zoo", "baz")},
@@ -469,7 +469,7 @@ func TestPasswordCredentialsTokenRequest_AuthCodeOption(t *testing.T) {
 			wantAccessToken:       "90d64460d14870c08c81352a05dedd3465940a7c",
 			wantTokenType:         "bearer",
 		},
-		"foo:bar,zoo:baz": {
+		"foo=bar&zoo=baz": {
 			username:              "user1",
 			password:              "password1",
 			authCodeOptions:       []AuthCodeOption{SetAuthURLParam("foo", "bar"), SetAuthURLParam("zoo", "baz")},


### PR DESCRIPTION
AuthCodeOption has been added to the PasswordCredentialsToken.
This allows the use of ExtraParams.
Test cases are included, so please take a look.

Fixes golang/oauth2#259