### PR TITLE
microsoft: added DeviceAuthURL to AzureADEndpoint

### DIFF
--- a/endpoints/endpoints.go
+++ b/endpoints/endpoints.go
@@ -68,8 +68,8 @@ var GitLab = oauth2.Endpoint{
 
 // Google is the endpoint for Google.
 var Google = oauth2.Endpoint{
-	AuthURL:  "https://accounts.google.com/o/oauth2/auth",
-	TokenURL: "https://oauth2.googleapis.com/token",
+	AuthURL:       "https://accounts.google.com/o/oauth2/auth",
+	TokenURL:      "https://oauth2.googleapis.com/token",
 	DeviceAuthURL: "https://oauth2.googleapis.com/device/code",
 }
 
@@ -227,8 +227,9 @@ func AzureAD(tenant string) oauth2.Endpoint {
 		tenant = "common"
 	}
 	return oauth2.Endpoint{
-		AuthURL:  "https://login.microsoftonline.com/" + tenant + "/oauth2/v2.0/authorize",
-		TokenURL: "https://login.microsoftonline.com/" + tenant + "/oauth2/v2.0/token",
+		AuthURL:       "https://login.microsoftonline.com/" + tenant + "/oauth2/v2.0/authorize",
+		TokenURL:      "https://login.microsoftonline.com/" + tenant + "/oauth2/v2.0/token",
+		DeviceAuthURL: "https://login.microsoftonline.com/" + tenant + "/oauth2/v2.0/devicecode",
 	}
 }
 

--- a/microsoft/microsoft.go
+++ b/microsoft/microsoft.go
@@ -25,7 +25,8 @@ func AzureADEndpoint(tenant string) oauth2.Endpoint {
 		tenant = "common"
 	}
 	return oauth2.Endpoint{
-		AuthURL:  "https://login.microsoftonline.com/" + tenant + "/oauth2/v2.0/authorize",
-		TokenURL: "https://login.microsoftonline.com/" + tenant + "/oauth2/v2.0/token",
+		AuthURL:       "https://login.microsoftonline.com/" + tenant + "/oauth2/v2.0/authorize",
+		TokenURL:      "https://login.microsoftonline.com/" + tenant + "/oauth2/v2.0/token",
+		DeviceAuthURL: "https://login.microsoftonline.com/" + tenant + "/oauth2/v2.0/devicecode",
 	}
 }


### PR DESCRIPTION
The Microsoft identity platform supports the device authorization grant:

https://learn.microsoft.com/en-us/entra/identity-platform/v2-oauth2-device-code

This PR adds the "https://login.microsoftonline.com/{tenant}/oauth2/v2.0/devicecode" DeviceAuthURL to the AzureADEndpoint.

Fixes golang/oauth2#700 