### PR TITLE
internal: optionally skip urlencoding client id and secret in header

### DIFF
--- a/oauth2.go
+++ b/oauth2.go
@@ -103,6 +103,10 @@ const (
 	// using HTTP Basic Authorization. This is an optional style
 	// described in the OAuth2 RFC 6749 section 2.3.1.
 	AuthStyleInHeader AuthStyle = 2
+
+	// AuthStyleInHeaderWithoutEncoding is similar to the AuthStyleInHeader,
+	// but it doesn't url encode client_id and client_password
+	AuthStyleInHeaderWithoutEncoding AuthStyle = 3
 )
 
 var (


### PR DESCRIPTION
Resolves #710. This is related to #237.

Although https://tools.ietf.org/html/rfc6749#section-2.3.1 states that clientID & clientSecret must be url encoded in the authorization header some sites don't do this thus resulting in authentication failure. 