### PR TITLE
oauth2/google: fix remove content-type header from idms get requests

### DIFF
--- a/google/externalaccount/aws.go
+++ b/google/externalaccount/aws.go
@@ -520,7 +520,6 @@ func (cs *awsCredentialSource) getMetadataSecurityCredentials(roleName string, h
 	if err != nil {
 		return result, err
 	}
-	req.Header.Add("Content-Type", "application/json")
 
 	for name, value := range headers {
 		req.Header.Add(name, value)


### PR DESCRIPTION
This is a fix on the https://github.com/googleapis/google-cloud-go/pull/9508.
The aws provider in that library is a ported dependency from here.