### PR TITLE
Update ReuseTokenSourceWithExpiry doc comment to begin with correct func name (Issue #715)

### DIFF
--- a/oauth2.go
+++ b/oauth2.go
@@ -393,7 +393,7 @@ func ReuseTokenSource(t *Token, src TokenSource) TokenSource {
 	}
 }
 
-// ReuseTokenSource returns a TokenSource that acts in the same manner as the
+// ReuseTokenSourceWithExpiry returns a TokenSource that acts in the same manner as the
 // TokenSource returned by ReuseTokenSource, except the expiry buffer is
 // configurable. The expiration time of a token is calculated as
 // t.Expiry.Add(-earlyExpiry).


### PR DESCRIPTION
<h3> Issue #715 </h3>

***
Doc comment began with incorrect func name. This just updates that.