### PR TITLE
fix: extra func - add nil check

### DIFF
--- a/token.go
+++ b/token.go
@@ -99,6 +99,10 @@ func (t *Token) WithExtra(extra interface{}) *Token {
 // Extra fields are key-value pairs returned by the server as a
 // part of the token retrieval response.
 func (t *Token) Extra(key string) interface{} {
+	if t.raw == nil {
+		return nil
+	}
+	
 	if raw, ok := t.raw.(map[string]interface{}); ok {
 		return raw[key]
 	}


### PR DESCRIPTION
In unit test situations, it's possible that extra is nil