### PR TITLE
Include context on deviceauth requests

### DIFF
--- a/deviceauth.go
+++ b/deviceauth.go
@@ -98,7 +98,7 @@ func retrieveDeviceAuth(ctx context.Context, c *Config, v url.Values) (*DeviceAu
 		return nil, errors.New("endpoint missing DeviceAuthURL")
 	}
 
-	req, err := http.NewRequest("POST", c.Endpoint.DeviceAuthURL, strings.NewReader(v.Encode()))
+	req, err := http.NewRequestWithContext(ctx, "POST", c.Endpoint.DeviceAuthURL, strings.NewReader(v.Encode()))
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Contexts aren't being attached to Request instances on creation, so if you have a custom round tripper which expects to be able to extract from the request context it doesn't work.

This appears to be a non-breaking change.

There's also a lot of other places which don't construct requests with a context even though the context is available, but I'm hesitant to touch things I'm not using myself.