### PR TITLE
oauth2: support client assertion in client_credentials

### DIFF
--- a/clientcredentials/clientcredentials_test.go
+++ b/clientcredentials/clientcredentials_test.go
@@ -12,16 +12,26 @@ import (
 	"net/http/httptest"
 	"net/url"
 	"testing"
+
+	"golang.org/x/oauth2"
 )
 
-func newConf(serverURL string) *Config {
-	return &Config{
+func newConf(serverURL string, assertion bool) *Config {
+	conf := &Config{
 		ClientID:       "CLIENT_ID",
-		ClientSecret:   "CLIENT_SECRET",
 		Scopes:         []string{"scope1", "scope2"},
 		TokenURL:       serverURL + "/token",
 		EndpointParams: url.Values{"audience": {"audience1"}},
+		AuthStyle:      oauth2.AuthStyleInParams,
 	}
+	if assertion {
+		conf.ClientAssertionFn = func(ctx context.Context) (string, error) {
+			return "CLIENT_ASSERTION", nil
+		}
+	} else {
+		conf.ClientSecret = "CLIENT_SECRET"
+	}
+	return conf
 }
 
 type mockTransport struct {
@@ -69,45 +79,70 @@ func TestTokenSourceGrantTypeOverride(t *testing.T) {
 	}
 }
 
+func assert(t *testing.T, want, got string) {
+	t.Helper()
+	if got != want {
+		t.Errorf("got %q; want %q", got, want)
+	}
+}
+
 func TestTokenRequest(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.String() != "/token" {
 			t.Errorf("authenticate client request URL = %q; want %q", r.URL, "/token")
 		}
-		headerAuth := r.Header.Get("Authorization")
-		if headerAuth != "Basic Q0xJRU5UX0lEOkNMSUVOVF9TRUNSRVQ=" {
-			t.Errorf("Unexpected authorization header, %v is found.", headerAuth)
-		}
+
 		if got, want := r.Header.Get("Content-Type"), "application/x-www-form-urlencoded"; got != want {
 			t.Errorf("Content-Type header = %q; want %q", got, want)
 		}
-		body, err := ioutil.ReadAll(r.Body)
-		if err != nil {
-			r.Body.Close()
-		}
-		if err != nil {
-			t.Errorf("failed reading request body: %s.", err)
-		}
-		if string(body) != "audience=audience1&grant_type=client_credentials&scope=scope1+scope2" {
-			t.Errorf("payload = %q; want %q", string(body), "grant_type=client_credentials&scope=scope1+scope2")
+
+		assert(t, "audience1", r.FormValue("audience"))
+		assert(t, "CLIENT_ID", r.FormValue("client_id"))
+		assert(t, "client_credentials", r.FormValue("grant_type"))
+		assert(t, "scope1 scope2", r.FormValue("scope"))
+		if r.FormValue("client_secret") != "" {
+			assert(t, "CLIENT_SECRET", r.FormValue("client_secret"))
+		} else {
+			assert(t, "CLIENT_ASSERTION", r.FormValue("client_assertion"))
+			assert(t, "urn:ietf:params:oauth:client-assertion-type:jwt-bearer", r.FormValue("client_assertion_type"))
 		}
 		w.Header().Set("Content-Type", "application/x-www-form-urlencoded")
 		w.Write([]byte("access_token=90d64460d14870c08c81352a05dedd3465940a7c&token_type=bearer"))
 	}))
 	defer ts.Close()
-	conf := newConf(ts.URL)
-	tok, err := conf.Token(context.Background())
-	if err != nil {
-		t.Error(err)
+
+	type testCase struct {
+		name string
+		conf *Config
 	}
-	if !tok.Valid() {
-		t.Fatalf("token invalid. got: %#v", tok)
+
+	tests := []testCase{
+		{
+			name: "client id and client_secret",
+			conf: newConf(ts.URL, false),
+		},
+		{
+			name: "client id and client_assertion",
+			conf: newConf(ts.URL, true),
+		},
 	}
-	if tok.AccessToken != "90d64460d14870c08c81352a05dedd3465940a7c" {
-		t.Errorf("Access token = %q; want %q", tok.AccessToken, "90d64460d14870c08c81352a05dedd3465940a7c")
-	}
-	if tok.TokenType != "bearer" {
-		t.Errorf("token type = %q; want %q", tok.TokenType, "bearer")
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			tok, err := tc.conf.Token(context.Background())
+			if err != nil {
+				t.Error(err)
+			}
+			if !tok.Valid() {
+				t.Fatalf("token invalid. got: %#v", tok)
+			}
+			if tok.AccessToken != "90d64460d14870c08c81352a05dedd3465940a7c" {
+				t.Errorf("Access token = %q; want %q", tok.AccessToken, "90d64460d14870c08c81352a05dedd3465940a7c")
+			}
+			if tok.TokenType != "bearer" {
+				t.Errorf("token type = %q; want %q", tok.TokenType, "bearer")
+			}
+		})
 	}
 }
 
@@ -132,7 +167,7 @@ func TestTokenRefreshRequest(t *testing.T) {
 		io.WriteString(w, `{"access_token": "foo", "refresh_token": "bar"}`)
 	}))
 	defer ts.Close()
-	conf := newConf(ts.URL)
+	conf := newConf(ts.URL, false)
 	c := conf.Client(context.Background())
 	c.Get(ts.URL + "/somethingelse")
 }


### PR DESCRIPTION
Maybe solves #744 as this adds client assertion support for `client_credentials` (@naizerjohn-ms is there really use-case for adding this to another grant_types than just `client_credentials`?)

Like mentioned in #744 this library is missing client_assertion support, which is kind of important feature nowadays as people does not want to use static credentials. 

Example how to use it (we are reading kubernetes serviceaccount file and passing the JWT as client assertion towards entra id):
```
	creds := &clientcredentials.Config{
		ClientID: "clientid",
		TokenURL: "https://entraidtokenurl",
		Scopes:   []string{"https://graph.microsoft.com/.default", "openid"},
		ClientAssertionFn: func(ctx context.Context) (string, error) {
			token, err := os.ReadFile("mytoken")
			if err != nil {
				return "", err
			}
			return string(token), nil
		},
	}
	client := creds.Client(ctx)
```

