### PR TITLE
fix(google/externalaccount/filecredsource.go): improve error message in subjectToken function to include the actual error detail

### DIFF
--- a/google/externalaccount/filecredsource.go
+++ b/google/externalaccount/filecredsource.go
@@ -26,7 +26,7 @@ func (cs fileCredentialSource) credentialSourceType() string {
 func (cs fileCredentialSource) subjectToken() (string, error) {
 	tokenFile, err := os.Open(cs.File)
 	if err != nil {
-		return "", fmt.Errorf("oauth2/google/externalaccount: failed to open credential file %q due to %v", cs.File, err)
+		return "", fmt.Errorf("oauth2/google/externalaccount: failed to open credential file %q: %v", cs.File, err)
 	}
 	defer tokenFile.Close()
 	tokenBytes, err := ioutil.ReadAll(io.LimitReader(tokenFile, 1<<20))

--- a/google/externalaccount/filecredsource.go
+++ b/google/externalaccount/filecredsource.go
@@ -26,7 +26,7 @@ func (cs fileCredentialSource) credentialSourceType() string {
 func (cs fileCredentialSource) subjectToken() (string, error) {
 	tokenFile, err := os.Open(cs.File)
 	if err != nil {
-		return "", fmt.Errorf("oauth2/google/externalaccount: failed to open credential file %q", cs.File)
+		return "", fmt.Errorf("oauth2/google/externalaccount: failed to open credential file %q due to %v", cs.File, err)
 	}
 	defer tokenFile.Close()
 	tokenBytes, err := ioutil.ReadAll(io.LimitReader(tokenFile, 1<<20))


### PR DESCRIPTION
It was unclear to me why credentials file couldn't open. This should clear up from user log if file is missing, or otherwise.