### PR TITLE
retrieveDeviceAuth: Call r.Body.Close()

### DIFF
--- a/deviceauth.go
+++ b/deviceauth.go
@@ -111,6 +111,7 @@ func retrieveDeviceAuth(ctx context.Context, c *Config, v url.Values) (*DeviceAu
 		return nil, err
 	}
 
+	defer r.Body.Close()
 	body, err := io.ReadAll(io.LimitReader(r.Body, 1<<20))
 	if err != nil {
 		return nil, fmt.Errorf("oauth2: cannot auth device: %v", err)


### PR DESCRIPTION
Close the response body after reading it in the DeviceAuth logic.

The `retrieveDeviceAuth` function did not close the response body. However, the net/http documentation states that one is expected to close the response body after one sends an HTTP request and reads the response body.  In addition, [the `doTokenRoundTrip` function *does* call `r.Body.Close()`](https://github.com/Miciah/oauth2/blob/ffeca96aa76167a098068334a567bb7c0975acc8/internal/token.go#L255-L261).  (Some other functions use a client with [a custom Transport that automatically closes the body](https://github.com/Miciah/oauth2/blob/ffeca96aa76167a098068334a567bb7c0975acc8/transport.go#L30-L37), but that is not the case for `retrieveDeviceAuth` or `doTokenRoundTrip`.)

Follow-up to commit e3fb0fb3af0ee7c0c62e31c393cbcfce6b2af5bf.

---

I noticed the missing `r.Body.Close()` call while reviewing a vendor bump in a project that I help maintain.  This project doesn't actually use DeviceAuth; I was just skimming through the newly vendored code when I noticed the questionable logic.  