### PR TITLE
golang/oauth2: add client_id to support Microsoft Entra ID in int128/kubelogin

### DIFF
--- a/oauth2.go
+++ b/oauth2.go
@@ -224,6 +224,7 @@ func (c *Config) Exchange(ctx context.Context, code string, opts ...AuthCodeOpti
 	v := url.Values{
 		"grant_type": {"authorization_code"},
 		"code":       {code},
+		"client_id":  {c.ClientID},
 	}
 	if c.RedirectURL != "" {
 		v.Set("redirect_uri", c.RedirectURL)
@@ -280,6 +281,7 @@ func (tf *tokenRefresher) Token() (*Token, error) {
 	tk, err := retrieveToken(tf.ctx, tf.conf, url.Values{
 		"grant_type":    {"refresh_token"},
 		"refresh_token": {tf.refreshToken},
+		"client_id":     {tf.conf.ClientID},
 	})
 
 	if err != nil {

--- a/oauth2_test.go
+++ b/oauth2_test.go
@@ -108,7 +108,7 @@ func TestExchangeRequest(t *testing.T) {
 		if err != nil {
 			t.Errorf("Failed reading request body: %s.", err)
 		}
-		if string(body) != "code=exchange-code&grant_type=authorization_code&redirect_uri=REDIRECT_URL" {
+		if string(body) != "client_id=CLIENT_ID&code=exchange-code&grant_type=authorization_code&redirect_uri=REDIRECT_URL" {
 			t.Errorf("Unexpected exchange payload; got %q", body)
 		}
 		w.Header().Set("Content-Type", "application/x-www-form-urlencoded")
@@ -152,7 +152,7 @@ func TestExchangeRequest_CustomParam(t *testing.T) {
 		if err != nil {
 			t.Errorf("Failed reading request body: %s.", err)
 		}
-		if string(body) != "code=exchange-code&foo=bar&grant_type=authorization_code&redirect_uri=REDIRECT_URL" {
+		if string(body) != "client_id=CLIENT_ID&code=exchange-code&foo=bar&grant_type=authorization_code&redirect_uri=REDIRECT_URL" {
 			t.Errorf("Unexpected exchange payload, %v is found.", string(body))
 		}
 		w.Header().Set("Content-Type", "application/x-www-form-urlencoded")
@@ -198,7 +198,7 @@ func TestExchangeRequest_JSONResponse(t *testing.T) {
 		if err != nil {
 			t.Errorf("Failed reading request body: %s.", err)
 		}
-		if string(body) != "code=exchange-code&grant_type=authorization_code&redirect_uri=REDIRECT_URL" {
+		if string(body) != "client_id=CLIENT_ID&code=exchange-code&grant_type=authorization_code&redirect_uri=REDIRECT_URL" {
 			t.Errorf("Unexpected exchange payload, %v is found.", string(body))
 		}
 		w.Header().Set("Content-Type", "application/json")
@@ -436,7 +436,7 @@ func TestTokenRefreshRequest(t *testing.T) {
 			t.Errorf("Unexpected Content-Type header %q", headerContentType)
 		}
 		body, _ := ioutil.ReadAll(r.Body)
-		if string(body) != "grant_type=refresh_token&refresh_token=REFRESH_TOKEN" {
+		if string(body) != "client_id=CLIENT_ID&grant_type=refresh_token&refresh_token=REFRESH_TOKEN" {
 			t.Errorf("Unexpected refresh token payload %q", body)
 		}
 		w.Header().Set("Content-Type", "application/json")


### PR DESCRIPTION
golang/oauth2: add client_id to support Microsoft Entra ID in int128/kubelogin

Fixes golang/oauth2 https://github.com/golang/oauth2/issues/734
Afterwards fixes  int128/kubelogin https://github.com/int128/kubelogin/issues/536

Using OIDC int128/kubelogin with Entra ID leads to errors in several cases, because Entra ID expects`client_id` to be set.