### PR TITLE
endpoints: add links/provider for Discord

### DIFF
--- a/endpoints/endpoints.go
+++ b/endpoints/endpoints.go
@@ -35,6 +35,7 @@ var Cern = oauth2.Endpoint{
 	TokenURL: "https://oauth.web.cern.ch/OAuth/Token",
 }
 
+// Discord is the endpoint for Discord.
 var Discord = oauth2.Endpoint{
 	AuthURL:  "https://discord.com/oauth2/authorize",
 	TokenURL: "https://discord.com/api/oauth2/token",

--- a/endpoints/endpoints.go
+++ b/endpoints/endpoints.go
@@ -35,6 +35,11 @@ var Cern = oauth2.Endpoint{
 	TokenURL: "https://oauth.web.cern.ch/OAuth/Token",
 }
 
+var Discord = oauth2.Endpoint{
+	AuthURL:  "https://discord.com/oauth2/authorize",
+	TokenURL: "https://discord.com/api/oauth2/token",
+}
+
 // Facebook is the endpoint for Facebook.
 var Facebook = oauth2.Endpoint{
 	AuthURL:  "https://www.facebook.com/v3.2/dialog/oauth",


### PR DESCRIPTION
Endpoints are provided from
https://discord.com/developers/docs/topics/oauth2#shared-resources-oauth2-urls.