### PR TITLE
refactor: rely on requests with ctx

### DIFF
--- a/google/downscope/downscoping.go
+++ b/google/downscope/downscoping.go
@@ -193,7 +193,12 @@ func (dts downscopingTokenSource) Token() (*oauth2.Token, error) {
 	form.Add("options", string(b))
 
 	myClient := oauth2.NewClient(dts.ctx, nil)
-	resp, err := myClient.PostForm(dts.identityBindingEndpoint, form)
+	req, err := http.NewRequestWithContext(dts.ctx, http.MethodPost, dts.identityBindingEndpoint, strings.NewReader(form.Encode()))
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	resp, err := myClient.Do(req)
 	if err != nil {
 		return nil, fmt.Errorf("unable to generate POST Request %v", err)
 	}

--- a/jira/jira.go
+++ b/jira/jira.go
@@ -109,7 +109,12 @@ func (js jwtSource) Token() (*oauth2.Token, error) {
 
 	// Fetch access token from auth server
 	hc := oauth2.NewClient(js.ctx, nil)
-	resp, err := hc.PostForm(js.conf.Endpoint.TokenURL, v)
+	req, err := http.NewRequestWithContext(js.ctx, http.MethodPost, js.conf.Endpoint.TokenURL, strings.NewReader(v.Encode()))
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	resp, err := hc.Do(req)
 	if err != nil {
 		return nil, fmt.Errorf("oauth2: cannot fetch token: %v", err)
 	}

--- a/jwt/jwt.go
+++ b/jwt/jwt.go
@@ -131,7 +131,12 @@ func (js jwtSource) Token() (*oauth2.Token, error) {
 	v := url.Values{}
 	v.Set("grant_type", defaultGrantType)
 	v.Set("assertion", payload)
-	resp, err := hc.PostForm(js.conf.TokenURL, v)
+	req, err := http.NewRequestWithContext(js.ctx, http.MethodPost, js.conf.TokenURL, strings.NewReader(v.Encode()))
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	resp, err := hc.Do(req)
 	if err != nil {
 		return nil, fmt.Errorf("oauth2: cannot fetch token: %v", err)
 	}


### PR DESCRIPTION
Current implementation for oauth2 repo, specifically jwt, jira and google/downscope packages rely on .PostForm function which does not allow to specify a context. The context is available within the function and preferably should be used to give more control to the consumer

#769 