### PR TITLE
google/externalaccount: support memory CredentialSource for externalaccount package

### DIFF
--- a/google/externalaccount/memorycredsource.go
+++ b/google/externalaccount/memorycredsource.go
@@ -1,0 +1,48 @@
+// Copyright 2025 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package externalaccount
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+)
+
+type memoryCredentialSource struct {
+	Token  []byte
+	Format Format
+}
+
+func (cs memoryCredentialSource) credentialSourceType() string {
+	return "memory"
+}
+
+func (cs memoryCredentialSource) subjectToken() (string, error) {
+	tokenBytes := bytes.TrimSpace(cs.Token)
+	switch cs.Format.Type {
+	case "json":
+		jsonData := make(map[string]interface{})
+		err := json.Unmarshal(tokenBytes, &jsonData)
+		if err != nil {
+			return "", fmt.Errorf("oauth2/google/externalaccount: failed to unmarshal subject token memory: %v", err)
+		}
+		val, ok := jsonData[cs.Format.SubjectTokenFieldName]
+		if !ok {
+			return "", errors.New("oauth2/google/externalaccount: provided subject_token_field_name not found in credentials")
+		}
+		token, ok := val.(string)
+		if !ok {
+			return "", errors.New("oauth2/google/externalaccount: improperly formatted subject token")
+		}
+		return token, nil
+	case "text":
+		return string(tokenBytes), nil
+	case "":
+		return string(tokenBytes), nil
+	default:
+		return "", errors.New("oauth2/google/externalaccount: invalid credential_source memory format type")
+	}
+}

--- a/google/externalaccount/memorycredsource_test.go
+++ b/google/externalaccount/memorycredsource_test.go
@@ -1,0 +1,87 @@
+// Copyright 2025 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package externalaccount
+
+import (
+	"context"
+	"os"
+	"testing"
+)
+
+var testMemoryConfig = Config{
+	Audience:                       "32555940559.apps.googleusercontent.com",
+	SubjectTokenType:               "urn:ietf:params:oauth:token-type:jwt",
+	TokenURL:                       "http://localhost:8080/v1/token",
+	TokenInfoURL:                   "http://localhost:8080/v1/tokeninfo",
+	ServiceAccountImpersonationURL: "https://iamcredentials.googleapis.com/v1/projects/-/serviceAccounts/service-gcs-admin@$PROJECT_ID.iam.gserviceaccount.com:generateAccessToken",
+	ClientSecret:                   "notsosecret",
+	ClientID:                       "rbrgnognrhongo3bi4gb9ghg9g",
+}
+
+func TestRetrieveMemorySubjectToken(t *testing.T) {
+	textBaseCred, err := os.ReadFile(textBaseCredPath)
+	if err != nil {
+		t.Fatalf("Failed to read file %s: %v", textBaseCredPath, err)
+	}
+
+	jsonBaseCred, err := os.ReadFile(jsonBaseCredPath)
+	if err != nil {
+		t.Fatalf("Failed to read file %s: %v", jsonBaseCredPath, err)
+	}
+
+	var memorySourceTests = []struct {
+		name string
+		cs   CredentialSource
+		want string
+	}{
+		{
+			name: "UntypedMemorySource",
+			cs: CredentialSource{
+				Memory: textBaseCred,
+			},
+			want: "street123",
+		},
+		{
+			name: "TextMemorySource",
+			cs: CredentialSource{
+				Memory: textBaseCred,
+				Format: Format{Type: fileTypeText},
+			},
+			want: "street123",
+		},
+		{
+			name: "JSONMemorySource",
+			cs: CredentialSource{
+				Memory: jsonBaseCred,
+				Format: Format{Type: fileTypeJSON, SubjectTokenFieldName: "SubjToken"},
+			},
+			want: "321road",
+		},
+	}
+
+	for _, test := range memorySourceTests {
+		test := test
+		tfc := testMemoryConfig
+		tfc.CredentialSource = &test.cs
+
+		t.Run(test.name, func(t *testing.T) {
+			base, err := tfc.parse(context.Background())
+			if err != nil {
+				t.Fatalf("parse() failed %v", err)
+			}
+
+			out, err := base.subjectToken()
+			if err != nil {
+				t.Errorf("Method subjectToken() errored.")
+			} else if test.want != out {
+				t.Errorf("got %v but want %v", out, test.want)
+			}
+
+			if got, want := base.credentialSourceType(), "memory"; got != want {
+				t.Errorf("got %v but want %v", got, want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Fixes golang/oauth2#772

This change introduces memory sourced credentials for the
google/externalaccount package. This is for credentials
that are already in memory and don't need to be loaded
from a file or URL.

I have tested this e2e and it works:

```
access_token = ya29.c.c0ASRK0G...<redacted>...azdkII
email = flux-mt-wi-poc@flux-gitops-playground.iam.gserviceaccount.com
```