### PR TITLE
Retrieve token before setting ticker to avoid initial delay

### DIFF
--- a/deviceauth.go
+++ b/deviceauth.go
@@ -157,6 +157,11 @@ func (c *Config) DeviceAccessToken(ctx context.Context, da *DeviceAuthResponse, 
 		opt.setValue(v)
 	}
 
+	tok, err := retrieveToken(ctx, c, v)
+	if err == nil {
+		return tok, nil
+	}
+
 	// "If no value is provided, clients MUST use 5 as the default."
 	// https://datatracker.ietf.org/doc/html/rfc8628#section-3.2
 	interval := da.Interval


### PR DESCRIPTION
This patch modifies the `DeviceAccessToken` function to avoid an unnecessary delay before the first token request is made.

Previously, the function waited for the first interval duration before making the initial call to `retrieveToken`. This behavior caused a delay.

This change introduces an immediate initial call to `retrieveToken` before entering the ticker loop. Subsequent polling continues to honor the server-specified interval, as expected.