### PR TITLE
oauth2: Handle nil headers in Transport.RoundTrip

### DIFF
--- a/transport.go
+++ b/transport.go
@@ -48,6 +48,9 @@ func (t *Transport) RoundTrip(req *http.Request) (*http.Response, error) {
 	}
 
 	req2 := req.Clone(req.Context())
+	if req2.Header == nil {
+		req2.Header = make(http.Header)
+	}
 	token.SetAuthHeader(req2)
 
 	// req.Body is assumed to be closed by the base RoundTripper.


### PR DESCRIPTION
Fixes an issue where setting auth headers on requests with nil Headers would cause a panic.

This change ensures that Transport.RoundTrip properly handles HTTP requests with nil headers by initializing the header 
map before setting the authorization header. Added a test case to verify this behavior as well.

The bug was introduced in 696f7b31289a98558822be146698b7834e477e63

cc @seankhliao (original author for review please)
 