### PR TITLE
endpoints: correct Naver OAuth2 endpoint URLs

### DIFF
--- a/endpoints/endpoints.go
+++ b/endpoints/endpoints.go
@@ -204,8 +204,8 @@ var Microsoft = oauth2.Endpoint{
 //
 // Documentation: https://developers.naver.com/docs/login/devguide/devguide.md
 var Naver = oauth2.Endpoint{
-	AuthURL:  "https://nid.naver.com/oauth2/authorize",
-	TokenURL: "https://nid.naver.com/oauth2/token",
+	AuthURL:  "https://nid.naver.com/oauth2.0/authorize",
+	TokenURL: "https://nid.naver.com/oauth2.0/token",
 }
 
 // NokiaHealth is the endpoint for Nokia Health.


### PR DESCRIPTION
Fixing an incorrect Naver OAuth2 endpoint URLs:

AuthURL : https://developers.naver.com/docs/login/devguide/devguide.md#3-4-2-%EB%84%A4%EC%9D%B4%EB%B2%84-%EB%A1%9C%EA%B7%B8%EC%9D%B8-%EC%97%B0%EB%8F%99-url-%EC%83%9D%EC%84%B1%ED%95%98%EA%B8%B0
TokenURL : https://developers.naver.com/docs/login/devguide/devguide.md#3-4-4-%EC%A0%91%EA%B7%BC-%ED%86%A0%ED%81%B0-%EB%B0%9C%EA%B8%89-%EC%9A%94%EC%B2%AD