### PR TITLE
oauth2: use strings.Builder instead of bytes.Buffer

### DIFF
--- a/google/externalaccount/aws.go
+++ b/google/externalaccount/aws.go
@@ -5,7 +5,6 @@
 package externalaccount
 
 import (
-	"bytes"
 	"context"
 	"crypto/hmac"
 	"crypto/sha256"
@@ -148,13 +147,13 @@ func canonicalHeaders(req *http.Request) (string, string) {
 	}
 	sort.Strings(headers)
 
-	var fullHeaders bytes.Buffer
+	var fullHeaders strings.Builder
 	for _, header := range headers {
 		headerValue := strings.Join(lowerCaseHeaders[header], ",")
 		fullHeaders.WriteString(header)
-		fullHeaders.WriteRune(':')
+		fullHeaders.WriteByte(':')
 		fullHeaders.WriteString(headerValue)
-		fullHeaders.WriteRune('\n')
+		fullHeaders.WriteByte('\n')
 	}
 
 	return strings.Join(headers, ";"), fullHeaders.String()

--- a/oauth2.go
+++ b/oauth2.go
@@ -9,7 +9,6 @@
 package oauth2 // import "golang.org/x/oauth2"
 
 import (
-	"bytes"
 	"context"
 	"errors"
 	"net/http"
@@ -158,7 +157,7 @@ func SetAuthURLParam(key, value string) AuthCodeOption {
 // PKCE), https://www.oauth.com/oauth2-servers/pkce/ and
 // https://www.ietf.org/archive/id/draft-ietf-oauth-v2-1-09.html#name-cross-site-request-forgery (describing both approaches)
 func (c *Config) AuthCodeURL(state string, opts ...AuthCodeOption) string {
-	var buf bytes.Buffer
+	var buf strings.Builder
 	buf.WriteString(c.Endpoint.AuthURL)
 	v := url.Values{
 		"response_type": {"code"},


### PR DESCRIPTION
The former does not make a copy of the accumulated buffer
to produce a string.

WriteByte() is faster than WriteRune() and we are not
appending non-ASCII here.